### PR TITLE
Fix Proxyshop for Full Art Basic Lands

### DIFF
--- a/proxyshop/templates.py
+++ b/proxyshop/templates.py
@@ -44,7 +44,8 @@ class BaseTemplate:
         # Flavor/reminder text
         if cfg.remove_flavor: self.layout.flavor_text = ""
         try:
-            if self.layout.oracle_text and cfg.remove_reminder:
+            # Full art basic lands have no oracle_text. Check for existence of attribute first.
+            if hasattr(self.layout, 'oracle_text') and self.layout.oracle_text and cfg.remove_reminder:
                 self.layout.oracle_text = format_text.strip_reminder_text(layout.oracle_text)
         finally: pass
 


### PR DESCRIPTION
Fixes the following error when trying to render full art basic lands:
```
 Exception in thread Thread-3 (render):
 Traceback (most recent call last):
   File "C:\Program Files\WindowsApps\PythonSoftwareFoundation.Python.3.10_3.10.1264.0_x64__qbz5n2kfra8p0\lib\threading.py", line 1009, in _bootstrap_inner
     self.run()
   File "C:\Program Files\WindowsApps\PythonSoftwareFoundation.Python.3.10_3.10.1264.0_x64__qbz5n2kfra8p0\lib\threading.py", line 946, in run
     self._target(*self._args, **self._kwargs)
   File "D:\Users\davidianstyle\Code\MTG-Proxyshop\main.py", line 238, in render
     self.result = card_template(layout, file).execute()
   File "D:\Users\davidianstyle\Code\MTG-Proxyshop\proxyshop\templates.py", line 1446, in __init__
     super().__init__(layout, file)
   File "D:\Users\davidianstyle\Code\MTG-Proxyshop\proxyshop\templates.py", line 47, in __init__
     if self.layout.oracle_text and cfg.remove_reminder:
 AttributeError: 'BasicLand' object has no attribute 'oracle_text'
```