### PR TITLE
Add .vscode to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -150,6 +150,9 @@ cython_debug/
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 .idea/
 
+# VSCode
+.vscode/
+
 # Specific to this project
 /art
 /out


### PR DESCRIPTION
The `.vscode` dir is analogous to the `.idea` dir for JetBrains users.