### PR TITLE
Undo deletion of duplicate line in text_layers.py

### DIFF
--- a/proxyshop/text_layers.py
+++ b/proxyshop/text_layers.py
@@ -133,6 +133,7 @@ class ExpansionSymbolField:
         # Ungroup if grouped
         if not self.layer.grouped:
             self.layer.grouped = False
+            self.layer.grouped = False  # Needed twice for some reason
         self.original = self.layer
 
         # One layer or multiple?


### PR DESCRIPTION
The duplicate line `self.layer.grouped = False` was deleted in https://github.com/MrTeferi/MTG-Proxyshop/pull/31 because it was believed to be a typo, but apparently it is needed. Woops!