### PR TITLE
Toggle text scaling

### DIFF
--- a/proxyshop/templates.py
+++ b/proxyshop/templates.py
@@ -324,17 +324,21 @@ class StarterTemplate (BaseTemplate):
         expansion_reference = psd.getLayer(con.layers['EXPANSION_REFERENCE'], text_and_icons)
 
         # Add text layers
-        self.tx_layers.extend([
+        self.tx_layers.append(
             txt_layers.BasicFormattedTextField(
                 layer = mana_cost,
                 contents = self.layout.mana_cost
-            ),
-            txt_layers.ScaledTextField(
+            )
+        )
+
+        self.tx_layers.append(
+            self.card_name_layer(
                 layer = name_selected,
                 contents = self.layout.name,
                 reference = mana_cost
             )
-        ])
+        )
+
         if not hasattr(self, "expansion_disabled"):
             self.tx_layers.append(
                 txt_layers.ExpansionSymbolField(
@@ -344,12 +348,27 @@ class StarterTemplate (BaseTemplate):
                     reference = expansion_reference
                 )
             )
+
         self.tx_layers.append(
-            txt_layers.ScaledTextField(
+            self.type_line_layer(
                 layer = type_line_selected,
                 contents = self.layout.type_line,
                 reference = expansion_symbol
             )
+        )
+
+    def card_name_layer(self, layer, contents, reference):
+        return txt_layers.ScaledTextField(
+            layer = layer,
+            contents = contents,
+            reference = reference
+        )
+
+    def type_line_layer(self, layer, contents, reference):
+        return txt_layers.ScaledTextField(
+            layer = layer,
+            contents = contents,
+            reference = reference
         )
 
     @staticmethod


### PR DESCRIPTION
Just a proof of concept of what I have in mind. Text resizing behaviour is controlled by which class is used (`ScaledTextField` vs `TextField`). Plugin classes now have the class hardcoded, so it's difficult to change this behaviour.

This PR turns basic_text_layers into a template method, with `card_name_layer` and `type_line_layer` as extension points. As usual this modification is 100% backwards compatible, and subclasses can override which object is returned. Might be useful also to have a clear extension point to customize the type line (e.g. old edition sport the "Summon" prefix before the type).