### PR TITLE
Text objects creation is extendable by plugins

### DIFF
--- a/proxyshop/templates.py
+++ b/proxyshop/templates.py
@@ -689,22 +689,42 @@ class StarterTemplate (BaseTemplate):
     def basic_text_layers(self):
 
         # Add text layers
-        self.text.extend([
+        self.text.append(
             txt_layers.BasicFormattedTextField(
                 layer = self.text_layer_mana,
                 contents = self.layout.mana_cost
-            ),
-            txt_layers.ScaledTextField(
+            )
+        )
+
+        self.text.append(
+            self.card_name_layer(
                 layer = self.text_layer_name,
                 contents = self.layout.name,
                 reference = self.text_layer_mana
-            ),
-            txt_layers.ScaledTextField(
+            )
+        )
+
+        self.text.append(
+            self.type_line_layer(
                 layer = self.text_layer_type,
                 contents = self.layout.type_line,
                 reference = self.expansion_symbol
             )
-        ])
+        )
+
+    def card_name_layer(self, layer, contents, reference):
+        return txt_layers.ScaledTextField(
+            layer = layer,
+            contents = contents,
+            reference = reference
+        )
+
+    def type_line_layer(self, layer, contents, reference):
+        return txt_layers.ScaledTextField(
+            layer = layer,
+            contents = contents,
+            reference = reference
+        )
 
 
 # EXTEND THIS FOR MOST NORMAL M15-STYLE TEMPLATES


### PR DESCRIPTION
Text resizing behaviour is controlled by which class is used (ScaledTextField vs TextField). Plugin classes now have the class hardcoded, so it's difficult to change this behaviour.

This PR turns `basic_text_layers` into a template method, with `card_name_layer` and `type_line_layer` as extension points. As usual this modification is 100% backwards compatible, and subclasses can override which object is returned. Might be useful also to have a clear extension point to customize the type line (e.g. old edition sport the "Summon" prefix before the type).

This is a rework of #40 after the modular rewrite. @MrTeferi even with the new structure it's difficult for a plugin to control which class is used to create text objects (which is the only way at the moment to prevent text resize).