### PR TITLE
Refactoring global constants, text layer classes, and frame logic

### DIFF
--- a/main.py
+++ b/main.py
@@ -185,23 +185,32 @@ class ProxyshopApp(App):
 		self.load_defaults()
 		try:
 
+			# Choose an image
 			app = ps.Application()
 			file = app.openDialog()
 			if file is None:
 				self.enable_buttons()
 				return
-			scryfall['filename'] = file[0]
+
+			# Setup file info
+			file = {
+				'filename': file[0],
+				'name': scryfall['name'],
+				'artist': scryfall['artist'],
+				'set': scryfall['set'],
+				'creator': None
+			}
 			console.update(
 				f"Rendering custom card: [b]{scryfall['name']}[/b]"
 			)
 
 			# If basic, manually call the BasicLand layout OBJ
 			if scryfall['name'] in con.basic_land_names:
-				layout = layouts.BasicLand(scryfall)
+				layout = layouts.BasicLand(file)
 			else:
 				# Instantiate layout OBJ, unpack scryfall json and store relevant data as attributes
 				scryfall['lang'] = "en"
-				try: layout = layouts.layout_map[scryfall['layout']](scryfall, scryfall['name'])
+				try: layout = layouts.layout_map[scryfall['layout']](scryfall, file)
 				except (KeyError, TypeError) as e:
 					console.update(f"Layout not supported!\n", e)
 					return
@@ -571,7 +580,7 @@ if __name__ == '__main__':
 	Path(os.path.join(cwd, "proxyshop/datas")).mkdir(mode=511, parents=True, exist_ok=True)
 
 	# Launch the app
-	__version__ = "v1.2.0"
+	__version__ = "v1.2.1"
 	Factory.register('HoverBehavior', HoverBehavior)
 	Builder.load_file(os.path.join(cwd, "proxyshop/kivy/proxyshop.kv"))
 	ProxyshopApp().run()

--- a/proxyshop/constants.py
+++ b/proxyshop/constants.py
@@ -4,319 +4,148 @@ Keep all global variables here.
 """
 import os
 import json
-cwd = os.getcwd()
+from dataclasses import dataclass
 
-# PATHS
-json_custom_path = os.path.join(cwd, "tmp\\custom.json")
-scryfall_scan_path = os.path.join(cwd, "tmp\\card.jpg")
 
-# Card classes - finer grained than Scryfall layouts
-normal_class = "normal"
-transform_front_class = "transform_front"
-transform_back_class = "transform_back"
-ixalan_class = "ixalan"
-mdfc_front_class = "mdfc_front"
-mdfc_back_class = "mdfc_back"
-mutate_class = "mutate"
-adventure_class = "adventure"
-leveler_class = "leveler"
-saga_class = "saga"
-miracle_class = "miracle"
-planeswalker_class = "planeswalker"
-pw_tf_front_class = "pw_tf_front"
-pw_tf_back_class = "pw_tf_back"
-pw_mdfc_front_class = "pw_mdfc_front"
-pw_mdfc_back_class = "pw_mdfc_back"
-snow_class = "snow"
-basic_class = "basic"
-planar_class = "planar"
-
-# LAYER NAMES
-layers = {
-    "WHITE": "W",
-    "BLUE": "U",
-    "BLACK": "B",
-    "RED": "R",
-    "GREEN": "G",
-    "WU": "WU",
-    "UB": "UB",
-    "BR": "BR",
-    "RG": "RG",
-    "GW": "GW",
-    "WB": "WB",
-    "BG": "BG",
-    "GU": "GU",
-    "UR": "UR",
-    "RW": "RW",
-    "ARTIFACT": "Artifact",
-    "COLORLESS": "Colorless",
-    "NONLAND": "Nonland",
-    "LAND": "Land",
-    "GOLD": "Gold",
-    "VEHICLE": "Vehicle",
+@dataclass
+class Layers:
+    """
+    Layer Names
+    """
+    WHITE = "W"
+    BLUE = "U"
+    BLACK = "B"
+    RED = "R"
+    GREEN = "G"
+    WU = "WU"
+    UB = "UB"
+    BR = "BR"
+    RG = "RG"
+    GW = "GW"
+    WB = "WB"
+    BG = "BG"
+    GU = "GU"
+    UR = "UR"
+    RW = "RW"
+    ARTIFACT = "Artifact"
+    COLORLESS = "Colorless"
+    NONLAND = "Nonland"
+    LAND = "Land"
+    GOLD = "Gold"
+    VEHICLE = "Vehicle"
 
     # frame layer group names
-    "PT_BOX": "PT Box",
-    "PT_AND_LEVEL_BOXES": "PT and Level Boxes",
-    "TWINS": "Name & Title Boxes",
-    "LEGENDARY_CROWN": "Legendary Crown",
-    "PINLINES_TEXTBOX": "Pinlines & Textbox",
-    "PINLINES_AND_SAGA_STRIPE": "Pinlines & Saga Stripe",
-    "PINLINES": "Pinlines",
-    "LAND_PINLINES_TEXTBOX": "Land Pinlines & Textbox",
-    "COMPANION": "Companion",
-    "BACKGROUND": "Background",
-    "NYX": "Nyx",
+    PT_BOX = "PT Box"
+    PT_AND_LEVEL_BOXES = "PT and Level Boxes"
+    TWINS = "Name & Title Boxes"
+    LEGENDARY_CROWN = "Legendary Crown"
+    PINLINES_TEXTBOX = "Pinlines & Textbox"
+    PINLINES_AND_SAGA_STRIPE = "Pinlines & Saga Stripe"
+    PINLINES = "Pinlines"
+    LAND_PINLINES_TEXTBOX = "Land Pinlines & Textbox"
+    COMPANION = "Companion"
+    BACKGROUND = "Background"
+    NYX = "Nyx"
 
     # borders
-    "BORDER": "Border",
-    "NORMAL_BORDER": "Normal Border",
-    "LEGENDARY_BORDER": "Legendary Border",
+    BORDER = "Border"
+    NORMAL_BORDER = "Normal Border"
+    LEGENDARY_BORDER = "Legendary Border"
 
     # shadows
-    "SHADOWS": "Shadows",
-    "HOLLOW_CROWN_SHADOW": "Hollow Crown Shadow",
+    SHADOWS = "Shadows"
+    HOLLOW_CROWN_SHADOW = "Hollow Crown Shadow"
 
     # legal
-    "LEGAL": "Legal",
-    "ARTIST": "Artist",
-    "SET": "Set",
-    "COLLECTOR": "Collector",
-    "TOP_LINE": "Top",
-    "BOTTOM_LINE": "Bottom",
+    LEGAL = "Legal"
+    ARTIST = "Artist"
+    SET = "Set"
+    COLLECTOR = "Collector"
+    TOP_LINE = "Top"
+    BOTTOM_LINE = "Bottom"
 
     # text and icons
-    "TEXT_AND_ICONS": "Text and Icons",
-    "NAME": "Card Name",
-    "NAME_SHIFT": "Card Name Shift",
-    "NAME_ADVENTURE": "Card Name - Adventure",
-    "TYPE_LINE": "Typeline",
-    "TYPE_LINE_SHIFT": "Typeline Shift",
-    "TYPE_LINE_ADVENTURE": "Typeline - Adventure",
-    "MANA_COST": "Mana Cost",
-    "MANA_COST_ADVENTURE": "Mana Cost - Adventure",
-    "EXPANSION_SYMBOL": "Expansion Symbol",
-    "EXPANSION_REFERENCE": "Expansion Reference",
-    "COLOR_INDICATOR": "Color Indicator",
-    "POWER_TOUGHNESS": "Power / Toughness",
-    "FLIPSIDE_POWER_TOUGHNESS": "Flipside Power / Toughness",
-    "RULES_TEXT": "Rules Text",
-    "RULES_TEXT_NONCREATURE": "Rules Text - Noncreature",
-    "RULES_TEXT_NONCREATURE_FLIP": "Rules Text - Noncreature Flip",
-    "RULES_TEXT_CREATURE": "Rules Text - Creature",
-    "RULES_TEXT_CREATURE_FLIP": "Rules Text - Creature Flip",
-    "RULES_TEXT_ADVENTURE": "Rules Text - Adventure",
-    "MUTATE": "Mutate",
-    "DIVIDER": "Divider",
+    TEXT_AND_ICONS = "Text and Icons"
+    NAME = "Card Name"
+    NAME_SHIFT = "Card Name Shift"
+    NAME_ADVENTURE = "Card Name - Adventure"
+    TYPE_LINE = "Typeline"
+    TYPE_LINE_SHIFT = "Typeline Shift"
+    TYPE_LINE_ADVENTURE = "Typeline - Adventure"
+    MANA_COST = "Mana Cost"
+    MANA_COST_ADVENTURE = "Mana Cost - Adventure"
+    EXPANSION_SYMBOL = "Expansion Symbol"
+    EXPANSION_REFERENCE = "Expansion Reference"
+    COLOR_INDICATOR = "Color Indicator"
+    POWER_TOUGHNESS = "Power / Toughness"
+    FLIPSIDE_POWER_TOUGHNESS = "Flipside Power / Toughness"
+    RULES_TEXT = "Rules Text"
+    RULES_TEXT_NONCREATURE = "Rules Text - Noncreature"
+    RULES_TEXT_NONCREATURE_FLIP = "Rules Text - Noncreature Flip"
+    RULES_TEXT_CREATURE = "Rules Text - Creature"
+    RULES_TEXT_CREATURE_FLIP = "Rules Text - Creature Flip"
+    RULES_TEXT_ADVENTURE = "Rules Text - Adventure"
+    MUTATE = "Mutate"
+    DIVIDER = "Divider"
+
+    # prototype
+    PROTO_TEXTBOX = "Prototype Textbox"
+    PROTO_MANABOX_SMALL = "Prototype Manabox 2"
+    PROTO_MANABOX_MEDIUM = "Prototype Manabox 3"
+    PROTO_PTBOX = "Prototype PT Box"
+    PROTO_MANA_COST = "Prototype Mana Cost"
+    PROTO_RULES = "Prototype Rules Text"
+    PROTO_PT = "Prototype Power / Toughness"
 
     # planar text and icons
-    "STATIC_ABILITY": "Static Ability",
-    "CHAOS_ABILITY": "Chaos Ability",
-    "CHAOS_SYMBOL": "Chaos Symbol",
-    "PHENOMENON": "Phenomenon",
-    "TEXTBOX": "Textbox",
+    STATIC_ABILITY = "Static Ability"
+    CHAOS_ABILITY = "Chaos Ability"
+    CHAOS_SYMBOL = "Chaos Symbol"
+    PHENOMENON = "Phenomenon"
+    TEXTBOX = "Textbox"
 
     # textbox references
-    "TEXTBOX_REFERENCE": "Textbox Reference",
-    "TEXTBOX_REFERENCE_LAND": "Textbox Reference Land",
-    "TEXTBOX_REFERENCE_ADVENTURE": "Textbox Reference - Adventure",
-    "MUTATE_REFERENCE": "Mutate Reference",
-    "PT_REFERENCE": "PT Adjustment Reference",
-    "PT_TOP_REFERENCE": "PT Top Reference",
+    TEXTBOX_REFERENCE = "Textbox Reference"
+    TEXTBOX_REFERENCE_LAND = "Textbox Reference Land"
+    TEXTBOX_REFERENCE_ADVENTURE = "Textbox Reference - Adventure"
+    MUTATE_REFERENCE = "Mutate Reference"
+    PT_REFERENCE = "PT Adjustment Reference"
+    PT_TOP_REFERENCE = "PT Top Reference"
 
     # planeswalker
-    "FIRST_ABILITY": "First Ability",
-    "SECOND_ABILITY": "Second Ability",
-    "THIRD_ABILITY": "Third Ability",
-    "FOURTH_ABILITY": "Fourth Ability",
-    "STARTING_LOYALTY": "Starting Loyalty",
-    "LOYALTY_GRAPHICS": "Loyalty Graphics",
-    "STATIC_TEXT": "Static Text",
-    "ABILITY_TEXT": "Ability Text",
-    "PW_ADJUSTMENT_REFERENCE": "PW Adjustment Reference",
-    "PW_TOP_REFERENCE": "PW Top Reference",
-    "COLON": "Colon",
-    "TEXT": "Text",
-    "COST": "Cost",
+    FIRST_ABILITY = "First Ability"
+    SECOND_ABILITY = "Second Ability"
+    THIRD_ABILITY = "Third Ability"
+    FOURTH_ABILITY = "Fourth Ability"
+    STARTING_LOYALTY = "Starting Loyalty"
+    LOYALTY_GRAPHICS = "Loyalty Graphics"
+    STATIC_TEXT = "Static Text"
+    ABILITY_TEXT = "Ability Text"
+    PW_ADJUSTMENT_REFERENCE = "PW Adjustment Reference"
+    PW_TOP_REFERENCE = "PW Top Reference"
+    COLON = "Colon"
+    TEXT = "Text"
+    COST = "Cost"
 
     # art frames
-    "ART_FRAME": "Art Frame",
-    "FULL_ART_FRAME": "Full Art Frame",
-    "BASIC_ART_FRAME": "Basic Art Frame",
-    "PLANESWALKER_ART_FRAME": "Planeswalker Art Frame",
-    "SCRYFALL_SCAN_FRAME": "Scryfall Scan Frame",
+    ART_FRAME = "Art Frame"
+    FULL_ART_FRAME = "Full Art Frame"
+    BASIC_ART_FRAME = "Basic Art Frame"
+    PLANESWALKER_ART_FRAME = "Planeswalker Art Frame"
+    SCRYFALL_SCAN_FRAME = "Scryfall Scan Frame"
 
     # transform
-    "TF_FRONT": "tf-front",
-    "TF_BACK": "tf-back",
-    "MDFC_FRONT": "mdfc-front",
-    "MDFC_BACK": "mdfc-back",
-    "MOON_ELDRAZI_DFC": "mooneldrazidfc",
+    TF_FRONT = "tf-front"
+    TF_BACK = "tf-back"
+    MDFC_FRONT = "mdfc-front"
+    MDFC_BACK = "mdfc-back"
+    MOON_ELDRAZI_DFC = "mooneldrazidfc"
 
     # mdfc
-    "TOP": "Top",
-    "BOTTOM": "Bottom",
-    "LEFT": "Left",
-    "RIGHT": "Right",
-}
-
-default_layer = "Layer 1"
-
-basic_land_names = [
-    "Plains",
-    "Island",
-    "Swamp",
-    "Mountain",
-    "Forest",
-    "Wastes",
-    "Snow-Covered Plains",
-    "Snow-Covered Island",
-    "Snow-Covered Swamp",
-    "Snow-Covered Mountain",
-    "Snow-Covered Forest"
-]
-
-# Card faces
-Faces = {
-    "FRONT": 0,
-    "BACK": 1,
-}
-
-# Font names
-font_rules_text = "PlantinMTPro-Regular"
-font_rules_text_bold = "PlantinMTPro-Bold"
-font_rules_text_italic = "PlantinMTPro-Italic"
-font_mana = "NDPMTG"
-font_subtext = "Beleren Small Caps Bold"
-font_collector = "Relay-Medium"
-
-# Font spacing
-modal_indent = 5.7
-line_break_lead = 2.4
-flavor_text_lead = 4.4
-flavor_text_lead_divider = 7
-
-# NDPMTG font dictionary to translate Scryfall symbols to font character sequences
-symbols = {
-    "{W/P}": "Qp",
-    "{U/P}": "Qp",
-    "{B/P}": "Qp",
-    "{R/P}": "Qp",
-    "{G/P}": "Qp",
-    "{W/U/P}": "Qqp",
-    "{U/B/P}": "Qqp",
-    "{B/R/P}": "Qqp",
-    "{R/G/P}": "Qqp",
-    "{G/W/P}": "Qqp",
-    "{W/B/P}": "Qqp",
-    "{B/G/P}": "Qqp",
-    "{G/U/P}": "Qqp",
-    "{U/R/P}": "Qqp",
-    "{R/W/P}": "Qqp",
-    "{E}": "e",
-    "{T}": "ot",
-    "{X}": "ox",
-    "{0}": "o0",
-    "{1}": "o1",
-    "{2}": "o2",
-    "{3}": "o3",
-    "{4}": "o4",
-    "{5}": "o5",
-    "{6}": "o6",
-    "{7}": "o7",
-    "{8}": "o8",
-    "{9}": "o9",
-    "{10}": "oA",
-    "{11}": "oB",
-    "{12}": "oC",
-    "{13}": "oD",
-    "{14}": "oE",
-    "{15}": "oF",
-    "{16}": "oG",
-    "{20}": "oK",
-    "{W}": "ow",
-    "{U}": "ou",
-    "{B}": "ob",
-    "{R}": "or",
-    "{G}": "og",
-    "{C}": "oc",
-    "{W/U}": "QqLS",
-    "{U/B}": "QqMT",
-    "{B/R}": "QqNU",
-    "{R/G}": "QqOV",
-    "{G/W}": "QqPR",
-    "{W/B}": "QqLT",
-    "{B/G}": "QqNV",
-    "{G/U}": "QqPS",
-    "{U/R}": "QqMU",
-    "{R/W}": "QqOR",
-    "{2/W}": "QqWR",
-    "{2/U}": "QqWS",
-    "{2/B}": "QqWT",
-    "{2/R}": "QqWU",
-    "{2/G}": "QqWV",
-    "{S}": "omn",
-    "{Q}": "ol",
-    "{CHAOS}": "?"
-}
-
-# Card rarities
-rarity_common = "common"
-rarity_uncommon = "uncommon"
-rarity_rare = "rare"
-rarity_mythic = "mythic"
-rarity_special = "special"
-rarity_bonus = "bonus"
-
-# Symbol colors basic
-clr_primary = {'r': 0, 'g': 0, 'b': 0}
-clr_secondary = {'r': 255, 'g': 255, 'b': 255}
-
-# Symbol colors outer
-clr_c = {'r': 204, 'g': 194, 'b': 193}
-clr_w = {'r': 255, 'g': 251, 'b': 214}
-clr_u = {'r': 170, 'g': 224, 'b': 250}
-clr_b = {'r': 204, 'g': 194, 'b': 193}
-clr_bh = {'r': 159, 'g': 146, 'b': 143}
-clr_r = {'r': 249, 'g': 169, 'b': 143}
-clr_g = {'r': 154, 'g': 211, 'b': 175}
-
-# Symbol colors inner
-clri_c = clr_primary
-clri_w = clr_primary
-clri_u = clr_primary
-clri_b = clr_primary
-clri_bh = clr_primary
-clri_r = clr_primary
-clri_g = clr_primary
-
-
-# Import symbol library
-with open(os.path.join(cwd, "proxyshop/symbols.json"), "r", encoding="utf-8-sig") as js:
-    set_symbols = json.load(js)
-
-# Import version tracker
-if not os.path.exists(os.path.join(cwd, "proxyshop/version_tracker.json")):
-    with open(os.path.join(cwd, "proxyshop/version_tracker.json"), "w", encoding="utf-8") as tr:
-        json.dump({}, tr, indent=4)
-with open(os.path.join(cwd, "proxyshop/version_tracker.json"), "r", encoding="utf-8") as tr:
-    try: versions = json.load(tr)
-    except json.decoder.JSONDecodeError: versions = {}
-
-# HTTP Header
-http_header = {
-    'User-Agent': 'Mozilla/5.0 (Windows NT 6.1;'
-    ' WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/32.0.1700.107 Safari/537.36'
-}
-
-# API Keys
-with open(os.path.join(cwd, "proxyshop/env.json"), "r", encoding="utf-8") as api_keys:
-    keys = json.load(api_keys)
-    g_api = keys['g_api']
-    a_api = keys['a_api']
-# Manual definitions
-# g_api = ""
-# a_api = ""
+    TOP = "Top"
+    BOTTOM = "Bottom"
+    LEFT = "Left"
+    RIGHT = "Right"
 
 
 # For object permanence
@@ -338,92 +167,185 @@ class Constants:
 
     def load_values(self):
 
-        # PATHS
-        self.cwd = cwd
-        self.json_custom_path = json_custom_path
-        self.scryfall_scan_path = scryfall_scan_path
+        # Current working directory
+        self.cwd = os.getcwd()
+
+        # Import version tracker
+        if not os.path.exists(os.path.join(self.cwd, "proxyshop/version_tracker.json")):
+            with open(os.path.join(self.cwd, "proxyshop/version_tracker.json"), "w", encoding="utf-8") as tr:
+                json.dump({}, tr, indent=4)
+        with open(os.path.join(self.cwd, "proxyshop/version_tracker.json"), "r", encoding="utf-8") as tr:
+            try:
+                self.versions = json.load(tr)
+            except json.decoder.JSONDecodeError:
+                self.versions = {}
+
+        # Import API Keys
+        with open(os.path.join(self.cwd, "proxyshop/env.json"), "r", encoding="utf-8") as api_keys:
+            keys = json.load(api_keys)
+            self.google_api = keys['g_api']
+            self.amazon_api = keys['a_api']
+
+        # Important paths
+        self.json_custom_path = os.path.join(self.cwd, "tmp\\custom.json")
+        self.scryfall_scan_path = os.path.join(self.cwd, "tmp\\card.jpg")
 
         # Card classes - finer grained than Scryfall layouts
-        self.normal_class = normal_class
-        self.transform_front_class = transform_front_class
-        self.transform_back_class = transform_back_class
-        self.ixalan_class = ixalan_class
-        self.mdfc_front_class = mdfc_front_class
-        self.mdfc_back_class = mdfc_back_class
-        self.mutate_class = mutate_class
-        self.adventure_class = adventure_class
-        self.leveler_class = leveler_class
-        self.saga_class = saga_class
-        self.miracle_class = miracle_class
-        self.planeswalker_class = planeswalker_class
-        self.pw_tf_front_class = pw_tf_front_class
-        self.pw_tf_back_class = pw_tf_back_class
-        self.pw_mdfc_front_class = pw_mdfc_front_class
-        self.pw_mdfc_back_class = pw_mdfc_back_class
-        self.snow_class = snow_class
-        self.basic_class = basic_class
-        self.planar_class = planar_class
+        self.normal_class = "normal"
+        self.transform_front_class = "transform_front"
+        self.transform_back_class = "transform_back"
+        self.ixalan_class = "ixalan"
+        self.mdfc_front_class = "mdfc_front"
+        self.mdfc_back_class = "mdfc_back"
+        self.mutate_class = "mutate"
+        self.adventure_class = "adventure"
+        self.leveler_class = "leveler"
+        self.saga_class = "saga"
+        self.miracle_class = "miracle"
+        self.planeswalker_class = "planeswalker"
+        self.pw_tf_front_class = "pw_tf_front"
+        self.pw_tf_back_class = "pw_tf_back"
+        self.pw_mdfc_front_class = "pw_mdfc_front"
+        self.pw_mdfc_back_class = "pw_mdfc_back"
+        self.snow_class = "snow"
+        self.basic_class = "basic"
+        self.planar_class = "planar"
+        self.prototype_class = "prototype"
 
         # Layer names
-        self.layers = layers
-        self.default_layer = default_layer
+        self.layers = Layers()
+        self.default_layer = "Layer 1"
 
-        # Cards
-        self.symbols = symbols
-        self.basic_land_names = basic_land_names
-        self.set_symbols = set_symbols.copy()
-        self.Faces = Faces
+        # Symbol dictionary for NDPMTG font
+        self.symbols = {
+            "{W/P}": "Qp",
+            "{U/P}": "Qp",
+            "{B/P}": "Qp",
+            "{R/P}": "Qp",
+            "{G/P}": "Qp",
+            "{W/U/P}": "Qqp",
+            "{U/B/P}": "Qqp",
+            "{B/R/P}": "Qqp",
+            "{R/G/P}": "Qqp",
+            "{G/W/P}": "Qqp",
+            "{W/B/P}": "Qqp",
+            "{B/G/P}": "Qqp",
+            "{G/U/P}": "Qqp",
+            "{U/R/P}": "Qqp",
+            "{R/W/P}": "Qqp",
+            "{E}": "e",
+            "{T}": "ot",
+            "{X}": "ox",
+            "{0}": "o0",
+            "{1}": "o1",
+            "{2}": "o2",
+            "{3}": "o3",
+            "{4}": "o4",
+            "{5}": "o5",
+            "{6}": "o6",
+            "{7}": "o7",
+            "{8}": "o8",
+            "{9}": "o9",
+            "{10}": "oA",
+            "{11}": "oB",
+            "{12}": "oC",
+            "{13}": "oD",
+            "{14}": "oE",
+            "{15}": "oF",
+            "{16}": "oG",
+            "{20}": "oK",
+            "{W}": "ow",
+            "{U}": "ou",
+            "{B}": "ob",
+            "{R}": "or",
+            "{G}": "og",
+            "{C}": "oc",
+            "{W/U}": "QqLS",
+            "{U/B}": "QqMT",
+            "{B/R}": "QqNU",
+            "{R/G}": "QqOV",
+            "{G/W}": "QqPR",
+            "{W/B}": "QqLT",
+            "{B/G}": "QqNV",
+            "{G/U}": "QqPS",
+            "{U/R}": "QqMU",
+            "{R/W}": "QqOR",
+            "{2/W}": "QqWR",
+            "{2/U}": "QqWS",
+            "{2/B}": "QqWT",
+            "{2/R}": "QqWU",
+            "{2/G}": "QqWV",
+            "{S}": "omn",
+            "{Q}": "ol",
+            "{CHAOS}": "?"
+        }
+
+        # Basic land dictionary
+        self.basic_land_names = [
+            "Plains",
+            "Island",
+            "Swamp",
+            "Mountain",
+            "Forest",
+            "Wastes",
+            "Snow-Covered Plains",
+            "Snow-Covered Island",
+            "Snow-Covered Swamp",
+            "Snow-Covered Mountain",
+            "Snow-Covered Forest"
+        ]
+
+        # Import set symbol library
+        with open(os.path.join(self.cwd, "proxyshop/symbols.json"), "r", encoding="utf-8-sig") as js:
+            self.set_symbols = json.load(js)
 
         # Font names
-        self.font_rules_text = font_rules_text
-        self.font_rules_text_italic = font_rules_text_italic
-        self.font_rules_text_bold = font_rules_text_bold
-        self.font_mana = font_mana
-        self.font_subtext = font_subtext
-        self.font_collector = font_collector
+        self.font_rules_text = "PlantinMTPro-Regular"
+        self.font_rules_text_bold = "PlantinMTPro-Bold"
+        self.font_rules_text_italic = "PlantinMTPro-Italic"
+        self.font_mana = "NDPMTG"
+        self.font_subtext = "Beleren Small Caps Bold"
+        self.font_collector = "Relay-Medium"
 
-        # Font formatting
-        self.modal_indent = modal_indent
-        self.line_break_lead = line_break_lead
-        self.flavor_text_lead = flavor_text_lead
-        self.flavor_text_lead_divider = flavor_text_lead_divider
-        self.flavor_text_color = None
+        # Text Layer formatting
+        self.modal_indent = 5.7
+        self.line_break_lead = 2.4
+        self.flavor_text_lead = 4.4
+        self.flavor_text_lead_divider = 7
 
         # Card rarities
-        self.rarity_common = rarity_common
-        self.rarity_uncommon = rarity_uncommon
-        self.rarity_rare = rarity_rare
-        self.rarity_mythic = rarity_mythic
-        self.rarity_special = rarity_special
-        self.rarity_bonus = rarity_bonus
+        self.rarity_common = "common"
+        self.rarity_uncommon = "uncommon"
+        self.rarity_rare = "rare"
+        self.rarity_mythic = "mythic"
+        self.rarity_special = "special"
+        self.rarity_bonus = "bonus"
 
         # Symbol colors
-        self.clr_c = clr_c
-        self.clr_w = clr_w
-        self.clr_u = clr_u
-        self.clr_b = clr_b
-        self.clr_bh = clr_bh
-        self.clr_r = clr_r
-        self.clr_g = clr_g
-        self.clri_c = clri_c
-        self.clri_w = clri_w
-        self.clri_u = clri_u
-        self.clri_b = clri_b
-        self.clri_bh = clri_bh
-        self.clri_r = clri_r
-        self.clri_g = clri_g
-        self.clr_primary = clr_primary
-        self.clr_secondary = clr_secondary
+        self.clr_primary = {'r': 0, 'g': 0, 'b': 0}
+        self.clr_secondary = {'r': 255, 'g': 255, 'b': 255}
+        self.clr_c = {'r': 204, 'g': 194, 'b': 193}
+        self.clr_w = {'r': 255, 'g': 251, 'b': 214}
+        self.clr_u = {'r': 170, 'g': 224, 'b': 250}
+        self.clr_b = {'r': 204, 'g': 194, 'b': 193}
+        self.clr_bh = {'r': 159, 'g': 146, 'b': 143}
+        self.clr_r = {'r': 249, 'g': 169, 'b': 143}
+        self.clr_g = {'r': 154, 'g': 211, 'b': 175}
+
+        # Inner Symbol colors
+        self.clri_c = self.clr_primary.copy()
+        self.clri_w = self.clr_primary.copy()
+        self.clri_u = self.clr_primary.copy()
+        self.clri_b = self.clr_primary.copy()
+        self.clri_bh = self.clr_primary.copy()
+        self.clri_r = self.clr_primary.copy()
+        self.clri_g = self.clr_primary.copy()
 
         # HTTP Header for requests
-        self.http_header = http_header
-
-        # Version tracker
-        self.versions = versions
-
-        # API keys
-        self.google_api = g_api
-        self.amazon_api = a_api
+        self.http_header = {
+            'User-Agent': 'Mozilla/5.0 (Windows NT 6.1;'
+            ' WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/32.0.1700.107 Safari/537.36'
+        }
 
         # Run headless
         self.headless = False
@@ -438,7 +360,7 @@ class Constants:
         """
         Updates the version tracker json with current dict.
         """
-        with open(os.path.join(cwd, "proxyshop/version_tracker.json"), "w", encoding="utf-8") as vt:
+        with open(os.path.join(self.cwd, "proxyshop/version_tracker.json"), "w", encoding="utf-8") as vt:
             json.dump(self.versions, vt, indent=4)
 
 # Global instance

--- a/proxyshop/creator.py
+++ b/proxyshop/creator.py
@@ -11,8 +11,8 @@ from kivy.uix.spinner import Spinner
 from kivy.uix.tabbedpanel import TabbedPanelItem, TabbedPanel
 from kivy.uix.textinput import TextInput
 from proxyshop import core
-cwd = os.getcwd()
 
+cwd = os.getcwd()
 
 """
 DISPLAY ELEMENTS
@@ -90,6 +90,7 @@ class CreatorNormalLayout(CreatorLayout):
         flavor_text = self.ids.flavor_text.text.replace("~", self.ids.name.text)
         scryfall = {
             "layout": "normal",
+            "object": "card",
             "set": self.ids.set.text,
             "name": self.ids.name.text,
             "oracle_text": oracle_text,
@@ -119,6 +120,7 @@ class CreatorPlaneswalkerLayout(CreatorLayout):
         ])
         scryfall = {
             "layout": "normal",
+            "object": "card",
             "set": self.ids.set.text,
             "name": self.ids.name.text,
             "artist": self.ids.artist.text,
@@ -142,20 +144,23 @@ class CreatorSagaLayout(CreatorLayout):
         num_lines = "I"
         if self.ids.line_1.text != "":
             text_arr.append(f"{num_lines} — " + self.ids.line_1.text.replace("~", self.ids.name.text))
-            num_lines+="I"
+            num_lines += "I"
         if self.ids.line_2.text != "":
             text_arr.append(f"{num_lines} — " + self.ids.line_2.text.replace("~", self.ids.name.text))
             num_lines += "I"
         if self.ids.line_3.text != "":
             text_arr.append(f"{num_lines} — " + self.ids.line_3.text.replace("~", self.ids.name.text))
-            if len(num_lines) == 3: num_lines = "IV"
-            else: num_lines += "I"
+            if len(num_lines) == 3:
+                num_lines = "IV"
+            else:
+                num_lines += "I"
         if self.ids.line_4.text != "":
             text_arr.append(f"{num_lines} — " + self.ids.line_4.text.replace("~", self.ids.name.text))
         text_arr.insert(0, f"Empty words.")
         rules_text = "\n".join(text_arr)
         scryfall = {
             "layout": "saga",
+            "object": "card",
             "flavor_text": "",
             "set": self.ids.set.text,
             "oracle_text": rules_text,
@@ -195,8 +200,10 @@ class InputItem(TextInput):
         Enable tab to next or previous input
         """
         if keycode[1] == 'tab':  # deal with cycle
-            if 'shift' in modifiers: nxt = self.get_focus_previous()
-            else: nxt = self.get_focus_next()
+            if 'shift' in modifiers:
+                nxt = self.get_focus_previous()
+            else:
+                nxt = self.get_focus_next()
             if nxt:
                 self.focus = False
                 nxt.focus = True

--- a/proxyshop/format_text.py
+++ b/proxyshop/format_text.py
@@ -3,7 +3,11 @@ Utility functions to format text
 """
 import math
 import re
+from typing import Optional, Union
+
 import photoshop.api as ps
+from photoshop.api._artlayer import ArtLayer
+
 import proxyshop.helpers as psd
 from proxyshop.constants import con
 if not con.headless:
@@ -242,7 +246,7 @@ def format_symbol(primary_action_list, starting_layer_ref, symbol_index, symbol_
     return current_ref
 
 
-def basic_format_text(input_string):
+def format_flavor_text(input_string: str):
     """
     Inserts the given string into the active layer and formats it without any of the more advanced features like
     italics strings, centering, etc.
@@ -251,345 +255,40 @@ def basic_format_text(input_string):
     # Is the active layer a text layer?
     if app.activeDocument.activeLayer.kind is not ps.LayerKind.TextLayer: return
 
-    # Locate symbols and update the input string
-    ret = locate_symbols(input_string)
-    input_string = ret['input_string']
-    symbol_indices = ret['symbol_indices']
-
     # Prepare action descriptor and reference variables
     layer_font_size = app.activeDocument.activeLayer.textItem.size
-    layer_text_color = app.activeDocument.activeLayer.textItem.color
     primary_action_descriptor = ps.ActionDescriptor()
     primary_action_list = ps.ActionList()
     desc119 = ps.ActionDescriptor()
     desc26 = ps.ActionDescriptor()
     desc25 = ps.ActionDescriptor()
     ref101 = ps.ActionReference()
-    desc141 = ps.ActionDescriptor()
-    desc142 = ps.ActionDescriptor()
-    desc143 = ps.ActionDescriptor()
-    list13 = ps.ActionList()
-    list14 = ps.ActionList()
-    idkerningRange = sID("kerningRange")
-    idparagraphStyleRange = sID("paragraphStyleRange")
-    idfontPostScriptName = sID("fontPostScriptName")
-    idfirstLineIndent = sID("firstLineIndent")
-    idparagraphStyle = sID("paragraphStyle")
-    idautoLeading = sID("autoLeading")
-    idstartIndent = sID("startIndent")
-    idspaceBefore = sID("spaceBefore")
-    idleadingType = sID("leadingType")
-    idspaceAfter = sID("spaceAfter")
-    idendIndent = sID("endIndent")
     idTxtS = sID("textStyle")
-    idsetd = cID("setd")
     idTxLr = cID("TxLr")
     idT = cID("T   ")
-    idFntN = cID("FntN")
-    idSz = cID("Sz  ")
     idPnt = cID("#Pnt")
-    idLdng = cID("Ldng")
     idTxtt = cID("Txtt")
-    idFrom = cID("From")
-    ref101.putEnumerated(
-        idTxLr,
-        cID("Ordn"),
-        cID("Trgt"))
 
     # Spin up the text insertion action
+    ref101.putEnumerated(idTxLr, cID("Ordn"), cID("Trgt"))
     desc119.putReference(cID("null"), ref101)
     primary_action_descriptor.putString(cID("Txt "), input_string)
-    desc25.putInteger(idFrom, 0)
+    desc25.putInteger(cID("From"), 0)
     desc25.putInteger(idT, len(input_string))
-    desc26.putString(idfontPostScriptName, con.font_rules_text)  # MPlantin default
-    desc26.putString(idFntN, con.font_rules_text)  # MPlantin default
-    desc26.putUnitDouble(idSz, idPnt, layer_font_size)
-    psd.apply_color(desc26, layer_text_color)
-    desc26.putBoolean(idautoLeading, False)
-    desc26.putUnitDouble(idLdng, idPnt, layer_font_size)
+    desc26.putString(sID("fontPostScriptName"), con.font_rules_text)  # MPlantin default
+    desc26.putString(cID("FntN"), con.font_rules_text)  # MPlantin default
+    desc26.putUnitDouble(cID("Sz  "), idPnt, layer_font_size)
+    desc26.putBoolean(sID("autoLeading"), False)
+    desc26.putUnitDouble(cID("Ldng"), idPnt, layer_font_size)
     desc25.putObject(idTxtS, idTxtS, desc26)
-    current_layer_ref = desc25
-
-    # Format each symbol correctly
-    for symbol_index in symbol_indices:
-        current_layer_ref = format_symbol(
-            primary_action_list = primary_action_list,
-            starting_layer_ref = current_layer_ref,
-            symbol_index = symbol_index['index'],
-            symbol_colors = symbol_index['colors'],
-            layer_font_size = layer_font_size,
-        )
-
-    primary_action_list.putObject(idTxtt, current_layer_ref)
+    primary_action_list.putObject(idTxtt, desc25)
     primary_action_descriptor.putList(idTxtt, primary_action_list)
-
-    # Paragraph formatting
-    desc141.putInteger(idFrom, 0)
-    desc141.putInteger(idT, len(input_string))  # input string length
-    desc142.putUnitDouble(idfirstLineIndent, idPnt, 0)
-    desc142.putUnitDouble(idstartIndent, idPnt, 0)
-    desc142.putUnitDouble(idendIndent, idPnt, 0)
-    desc142.putUnitDouble(idspaceBefore, idPnt, con.line_break_lead)
-    desc142.putUnitDouble(idspaceAfter, idPnt, 0)
-    desc142.putInteger(sID("dropCapMultiplier"), 1)
-    desc142.putEnumerated(idleadingType, idleadingType, sID("leadingBelow"))
-    desc143.putString(idfontPostScriptName, con.font_mana)  # NDPMTG default
-    desc143.putString(idFntN, con.font_rules_text)  # MPlantin default
-    desc143.putBoolean(idautoLeading, False)
-    primary_action_descriptor.putList(idparagraphStyleRange, list13)
-    primary_action_descriptor.putList(idkerningRange, list14)
-    list13 = ps.ActionList()
 
     # Push changes to document
     desc119.putObject(idT, idTxLr, primary_action_descriptor)
-    app.executeAction(idsetd, desc119, NO_DIALOG)
+    app.executeAction(cID("setd"), desc119, NO_DIALOG)
 
     # Reset layer's justification if needed and disable hyphenation
-    app.activeDocument.activeLayer.textItem.hyphenation = False
-
-
-def format_text(input_string, italics_strings, flavor_index, is_centered):
-    """
-    Inserts the given string into the active layer and formats it according to defined parameters with symbols
-    from the NDPMTG font.
-    @param input_string: The string to insert into the active layer
-    @param italics_strings: An array containing strings that should be italicized within the input_string.
-    @param flavor_index: The index at which linebreak spacing should be increased and any subsequent
-    chars should be italicized (where the card's flavor text begins)
-    @param is_centered: Should the input text should be center-justified
-    """
-    # Is the active layer a text layer?
-    if app.activeDocument.activeLayer.kind is not ps.LayerKind.TextLayer: return
-
-    # Record the layer's justification before modifying the layer in case it's reset along the way
-    layer_justification = app.activeDocument.activeLayer.textItem.justification
-
-    # Check if the flavor text contains a quote
-    if flavor_index >= 0: quote_index = input_string.find("\r", flavor_index + 3)
-    else: quote_index = -1
-
-    # Locate symbols and update the input string
-    ret = locate_symbols(input_string)
-    input_string = ret['input_string']
-    symbol_indices = ret['symbol_indices']
-
-    # Locate italics text indices
-    italics_indices = locate_italics(input_string, italics_strings)
-
-    # Prepare action descriptor and reference variables
-    layer_font_size = app.activeDocument.activeLayer.textItem.size
-    layer_text_color = app.activeDocument.activeLayer.textItem.color
-    primary_action_descriptor = ps.ActionDescriptor()
-    primary_action_list = ps.ActionList()
-    desc119 = ps.ActionDescriptor()
-    desc26 = ps.ActionDescriptor()
-    desc25 = ps.ActionDescriptor()
-    ref101 = ps.ActionReference()
-    desc141 = ps.ActionDescriptor()
-    desc142 = ps.ActionDescriptor()
-    desc143 = ps.ActionDescriptor()
-    list13 = ps.ActionList()
-    list14 = ps.ActionList()
-    idkerningRange = sID("kerningRange")
-    idparagraphStyleRange = sID("paragraphStyleRange")
-    idfontPostScriptName = sID("fontPostScriptName")
-    idfirstLineIndent = sID("firstLineIndent")
-    idparagraphStyle = sID("paragraphStyle")
-    idautoLeading = sID("autoLeading")
-    idstartIndent = sID("startIndent")
-    idspaceBefore = sID("spaceBefore")
-    idleadingType = sID("leadingType")
-    idspaceAfter = sID("spaceAfter")
-    idendIndent = sID("endIndent")
-    idTxtS = sID("textStyle")
-    idsetd = cID("setd")
-    idTxLr = cID("TxLr")
-    idT = cID("T   ")
-    idFntN = cID("FntN")
-    idSz = cID("Sz  ")
-    idPnt = cID("#Pnt")
-    idLdng = cID("Ldng")
-    idTxtt = cID("Txtt")
-    idFrom = cID("From")
-    ref101.putEnumerated(
-        idTxLr,
-        cID("Ordn"),
-        cID("Trgt"))
-
-    # Spin up the text insertion action
-    desc119.putReference(cID("null"), ref101)
-    primary_action_descriptor.putString(cID("Txt "), input_string)
-    desc25.putInteger(idFrom, 0)
-    desc25.putInteger(idT, len(input_string))
-    desc26.putString(idfontPostScriptName, con.font_rules_text)  # MPlantin default
-    desc26.putString(idFntN, con.font_rules_text)  # MPlantin default
-    desc26.putUnitDouble(idSz, idPnt, layer_font_size)
-    psd.apply_color(desc26, layer_text_color)
-    desc26.putBoolean(idautoLeading, False)
-    desc26.putUnitDouble(idLdng, idPnt, layer_font_size)
-    desc25.putObject(idTxtS, idTxtS, desc26)
-    current_layer_ref = desc25
-
-    # Bold the contents if necessary
-    if con.bold_rules_text and flavor_index != 0:
-        bold_action1 = ps.ActionDescriptor()
-        bold_action2 = ps.ActionDescriptor()
-        contents_index = len(input_string) - 1 if flavor_index < 0 else flavor_index - 1
-        primary_action_list.putObject(idTxtt, current_layer_ref)
-        bold_action1.putInteger(idFrom, 0)  # italics start index
-        bold_action1.putInteger(idT, contents_index)  # italics end index
-        bold_action2.putString(idfontPostScriptName, con.font_rules_text_bold)  # MPlantin italic default
-        bold_action2.putString(idFntN, con.font_rules_text_bold)  # MPlantin italic default
-        bold_action2.putUnitDouble(idSz, idPnt, layer_font_size)
-        bold_action2.putBoolean(idautoLeading, False)
-        bold_action2.putUnitDouble(idLdng, idPnt, layer_font_size)
-        bold_action1.putObject(idTxtS, idTxtS, bold_action2)
-        current_layer_ref = bold_action1
-
-    # Italicize text from our italics indices
-    for italics_index in italics_indices:
-        italics_action1 = ps.ActionDescriptor()
-        italics_action2 = ps.ActionDescriptor()
-        primary_action_list.putObject(idTxtt, current_layer_ref)
-        italics_action1.putInteger(idFrom, italics_index['start_index'])  # italics start index
-        italics_action1.putInteger(idT, italics_index['end_index'])  # italics end index
-        italics_action2.putString(idfontPostScriptName, con.font_rules_text_italic)  # MPlantin italic default
-        italics_action2.putString(idFntN, con.font_rules_text_italic)  # MPlantin italic default
-        italics_action2.putUnitDouble(idSz, idPnt, layer_font_size)
-        italics_action2.putBoolean(idautoLeading, False)
-        italics_action2.putUnitDouble(idLdng, idPnt, layer_font_size)
-        # Default text box
-
-        psd.apply_color(italics_action2, layer_text_color)
-
-        # End
-        italics_action1.putObject(idTxtS, idTxtS, italics_action2)
-        current_layer_ref = italics_action1
-
-    # Format each symbol correctly
-    for symbol_index in symbol_indices:
-        current_layer_ref = format_symbol(
-            primary_action_list = primary_action_list,
-            starting_layer_ref = current_layer_ref,
-            symbol_index = symbol_index['index'],
-            symbol_colors = symbol_index['colors'],
-            layer_font_size = layer_font_size,
-        )
-
-    primary_action_list.putObject(idTxtt, current_layer_ref)
-    primary_action_descriptor.putList(idTxtt, primary_action_list)
-
-    # Paragraph formatting
-    desc141.putInteger(idFrom, 0)
-    desc141.putInteger(idT, len(input_string))  # input string length
-    desc142.putUnitDouble(idfirstLineIndent, idPnt, 0)
-    desc142.putUnitDouble(idstartIndent, idPnt, 0)
-    desc142.putUnitDouble(idendIndent, idPnt, 0)
-    if is_centered:  # line break lead
-        desc142.putUnitDouble(idspaceBefore, idPnt, 0)
-    else:
-        desc142.putUnitDouble(idspaceBefore, idPnt, con.line_break_lead)
-    desc142.putUnitDouble(idspaceAfter, idPnt, 0)
-    desc142.putInteger(sID("dropCapMultiplier"), 1)
-    desc142.putEnumerated(idleadingType, idleadingType, sID("leadingBelow"))
-    desc143.putString(idfontPostScriptName, con.font_mana)  # NDPMTG default
-    desc143.putString(idFntN, con.font_rules_text)  # MPlantin default
-    desc143.putBoolean(idautoLeading, False)
-    primary_action_descriptor.putList(idparagraphStyleRange, list13)
-    primary_action_descriptor.putList(idkerningRange, list14)
-    list13 = ps.ActionList()
-
-    if input_string.find("\u2022") >= 0:
-        # Modal card with bullet points - adjust the formatting slightly
-        startIndexBullet = input_string.find("\u2022")
-        endIndexBullet = input_string.rindex("\u2022")
-        list13 = ps.ActionList()
-        list14 = ps.ActionList()
-        desc141 = ps.ActionDescriptor()
-        desc141.putInteger(idFrom, startIndexBullet)
-        desc141.putInteger(idT, endIndexBullet + 1)
-        desc142.putUnitDouble(idfirstLineIndent, idPnt, -con.modal_indent)  # negative modal indent
-        desc142.putUnitDouble(idstartIndent, idPnt, con.modal_indent)  # modal indent
-        desc142.putUnitDouble(idspaceBefore, idPnt, 1)
-        desc142.putUnitDouble(idspaceAfter, idPnt, 0)
-        desc143 = ps.ActionDescriptor()
-        desc143.putString(idfontPostScriptName, con.font_mana)  # NDPMTG default
-        desc143.putString(idFntN, con.font_rules_text)  # MPlantin default
-        desc143.putUnitDouble(idSz, idPnt, 12)
-        desc143.putBoolean(idautoLeading, False)
-        desc142.putObject(sID("defaultStyle"), idTxtS, desc143)
-        desc141.putObject(idparagraphStyle, idparagraphStyle, desc142)
-        list13.putObject(idparagraphStyleRange, desc141)
-        primary_action_descriptor.putList(idparagraphStyleRange, list13)
-        primary_action_descriptor.putList(idkerningRange, list14)
-
-    if flavor_index >= 0:
-        # Adjust line break spacing if there's a line break in the flavor text
-        list14 = ps.ActionList()
-        desc141 = ps.ActionDescriptor()
-        desc141.putInteger(idFrom, flavor_index + 3)
-        desc141.putInteger(idT, flavor_index + 4)
-        desc142.putUnitDouble(idfirstLineIndent, idPnt, 0)
-        idimpliedFirstLineIndent = sID("impliedFirstLineIndent")
-        desc142.putUnitDouble(idimpliedFirstLineIndent, idPnt, 0)
-        desc142.putUnitDouble(idstartIndent, idPnt, 0)
-        desc142.putUnitDouble(sID("impliedStartIndent"), idPnt, 0)
-        desc142.putUnitDouble(idspaceBefore, idPnt, con.flavor_text_lead)  # Lead size between rules and flavor text
-        desc141.putObject(idparagraphStyle, idparagraphStyle, desc142)
-        list13.putObject(idparagraphStyleRange, desc141)
-        primary_action_descriptor.putList(idparagraphStyleRange, list13)
-        primary_action_descriptor.putList(idkerningRange, list14)
-
-        # Adjust flavor text color
-        if con.flavor_text_color:
-            list15 = ps.ActionList()
-            desc144 = ps.ActionDescriptor()
-            desc145 = ps.ActionDescriptor()
-            desc144.PutInteger(sID("from"), flavor_index)
-            desc144.PutInteger(sID("to"), len(input_string))
-            desc145.putString(idfontPostScriptName, con.font_rules_text_italic)  # MPlantin italic default
-            desc145.putString(idFntN, con.font_rules_text_italic)  # MPlantin italic default
-            desc145.putUnitDouble(idSz, idPnt, layer_font_size)
-            desc145.putBoolean(idautoLeading, False)
-            desc145.putUnitDouble(idLdng, idPnt, layer_font_size)
-
-            psd.apply_color(desc145, con.flavor_text_color)
-
-            desc144.PutObject(sID("textStyle"), sID("textStyle"), desc145)
-            list15.PutObject(sID("textStyleRange"), desc144)
-            primary_action_descriptor.putList(sID("textStyleRange"), list15)
-
-    disable_justify = False
-    if quote_index >= 0:
-        # Adjust line break spacing if there's a line break in the flavor text
-        list14 = ps.ActionList()
-        desc141 = ps.ActionDescriptor()
-        desc141.putInteger(idFrom, quote_index + 3)
-        desc141.putInteger(idT, len(input_string))
-        desc142.putUnitDouble(idspaceBefore, idPnt, 0)
-        desc141.putObject(idparagraphStyle, idparagraphStyle, desc142)
-        list13.putObject(idparagraphStyleRange, desc141)
-
-        # Optional, align quote credit to right
-        if input_string.find('"\r—') >= 0 and con.align_classic_quote:
-            # Get start and ending index of quotation credit
-            index_start = input_string.find('"\r—') + 2
-            index_end = len(input_string) - 1
-
-            # Align this part, disable justification reset
-            list13 = classic_align_right(list13, index_start, index_end)
-            disable_justify = True
-
-        primary_action_descriptor.putList(idparagraphStyleRange, list13)
-        primary_action_descriptor.putList(idkerningRange, list14)
-
-    # Push changes to document
-    desc119.putObject(idT, idTxLr, primary_action_descriptor)
-    app.executeAction(idsetd, desc119, NO_DIALOG)
-
-    # Reset layer's justification if needed and disable hyphenation
-    if not disable_justify:
-        app.activeDocument.activeLayer.textItem.justification = layer_justification
     app.activeDocument.activeLayer.textItem.hyphenation = False
 
 
@@ -618,17 +317,6 @@ def generate_italics(card_text):
         italic_text.append(match)
 
     return italic_text
-
-
-def format_text_wrapper():
-    """
-    Wrapper for format_text which runs the function with the active layer's current text contents
-    and auto-generated italics array. Flavor text index and centered text not supported.
-    Super useful to add as a script action in Photoshop for making cards manually!
-    """
-    card_text = app.activeDocument.activeLayer.textItem.contents
-    italic_text = generate_italics(card_text)
-    format_text(card_text, italic_text, -1, False)
 
 
 def strip_reminder_text(oracle_text):
@@ -777,7 +465,11 @@ def scale_text_left_overlap(layer, reference) -> None:
         reference.textItem.contents = contents
 
 
-def scale_text_to_fit_reference(layer, ref, spacing: int = None):
+def scale_text_to_fit_reference(
+    layer: ArtLayer,
+    ref: Union[ArtLayer, int, float],
+    spacing: Optional[int] = None
+):
     """
     Resize a given text layer's contents (in 0.25 pt increments) until it fits inside a specified reference layer.
     The resulting text layer will have equal font and lead sizes.
@@ -786,13 +478,18 @@ def scale_text_to_fit_reference(layer, ref, spacing: int = None):
     @param spacing: [Optional] Amount of mandatory spacing at the bottom of text layer.
     """
     # Establish base variables, ensure a level of spacing at the margins
-    factor = 1
     if not ref: return
-    if not spacing:  # If no spacing provided, use default
-        spacing = int((app.activeDocument.width / 3264) * 64)
-    if app.activeDocument.width != 3264:
-        factor = psd.get_text_scale_factor(layer)
-    ref_height = psd.get_layer_dimensions(ref)['height'] - spacing
+    if isinstance(ref, int) or isinstance(ref, float):
+        # Only checking against fixed height
+        ref_height = ref
+    elif isinstance(ref, ArtLayer):
+        # Use a reference layer
+        if not spacing:  # If no spacing provided, use default
+            spacing = int((app.activeDocument.width / 3264) * 64)
+        ref_height = psd.get_layer_dimensions(ref)['height'] - spacing
+    else:
+        return
+    factor = psd.get_text_scale_factor(layer) or 1
     font_size = layer.textItem.size * factor
     step, half_step = 0.4, 0.2
 
@@ -808,37 +505,6 @@ def scale_text_to_fit_reference(layer, ref, spacing: int = None):
     layer.textItem.size = font_size
     layer.textItem.leading = font_size
     if ref_height < psd.get_text_layer_dimensions(layer)['height']:
-        font_size -= half_step
-        layer.textItem.size = font_size
-        layer.textItem.leading = font_size
-
-
-def scale_text_to_fit_height(layer, height: int):
-    """
-    Resize a given text layer's contents (in 0.25 pt increments) until it fits inside a specified reference layer.
-    The resulting text layer will have equal font and lead sizes.
-    @param layer: Text layer to scale.
-    @param height: Reference height to fit.
-    """
-    # Establish base variables, ensure a level of spacing at the margins
-    factor = 1
-    if app.activeDocument.width != 3264:
-        factor = psd.get_text_scale_factor(layer)
-    font_size = layer.textItem.size * factor
-    step, half_step = 0.4, 0.2
-
-    # Step down font and lead sizes by the step size, and update those sizes in the layer
-    if height > psd.get_text_layer_dimensions(layer)['height']: return
-    while height < psd.get_text_layer_dimensions(layer)['height']:
-        font_size -= step
-        layer.textItem.size = font_size
-        layer.textItem.leading = font_size
-
-    # Take a half step back up, check if still in bounds and adjust back if needed
-    font_size += half_step
-    layer.textItem.size = font_size
-    layer.textItem.leading = font_size
-    if height < psd.get_text_layer_dimensions(layer)['height']:
         font_size -= half_step
         layer.textItem.size = font_size
         layer.textItem.leading = font_size

--- a/proxyshop/gui.py
+++ b/proxyshop/gui.py
@@ -24,6 +24,8 @@ from kivy.uix.label import Label
 from kivy.uix.popup import Popup
 from kivy.uix.progressbar import ProgressBar
 from kivy.utils import get_color_from_hex
+
+from proxyshop.constants import con
 from proxyshop.core import (
     check_for_updates,
     update_template,
@@ -324,14 +326,23 @@ class UpdateEntry(BoxLayout):
         download.clear_widgets()
         download.add_widget(self.progress)
         result = await ak.run_in_thread(
-            lambda: update_template(self.data, self.progress.update_progress, self.progress.s3_update_progress
-        ), daemon=True)
+            lambda: update_template(
+                self.data,
+                self.progress.update_progress,
+                self.progress.s3_update_progress),
+            daemon=True
+        )
         await ak.sleep(.5)
         if result:
             self.root.ids.container.remove_widget(self.root.entries[self.data['id']])
         else:
             download.clear_widgets()
             download.add_widget(Label(text="[color=#a84747]FAILED[/color]", markup=True))
+
+    async def mark_updated(self):
+        self.root.ids.container.remove_widget(self.root.entries[self.data['id']])
+        con.versions[self.data['id']] = self.data['version_new']
+        con.update_version_tracker()
 
     def update_progress(self, tran: int, total: int) -> None:
         progress = int((tran/total)*100)

--- a/proxyshop/helpers.py
+++ b/proxyshop/helpers.py
@@ -1130,20 +1130,6 @@ def fill_expansion_symbol(reference, color=rgb_black()):
     app.activeDocument.selection.invert()
     app.activeDocument.selection.contract(1)
 
-    """ # Not necessary?
-    # Magic Wand cross select
-    click2 = ps.ActionDescriptor()
-    ref2 = ps.ActionReference()
-    ref2.putProperty(cID("Chnl"), cID("fsel"))
-    click2.putReference(cID("null"), ref2)
-    click2.putObject(cID("T   "), cID("Pnt "), coords)
-    click2.putInteger(cID("Tlrn"), 12)
-    click2.putBoolean(cID("AntA"), True)
-    click2.putBoolean(cID("Cntg"), False)
-    app.executeAction(cID("IntW"), click2)
-    app.activeDocument.selection.expand(4)
-    """
-
     # Make a new layer
     layer = app.activeDocument.artLayers.add()
     layer.name = "Expansion Mask"
@@ -1162,10 +1148,6 @@ def fill_expansion_symbol(reference, color=rgb_black()):
 
     # Clear Selection
     clear_selection()
-
-    # Maximum filter to keep the antialiasing normal
-    # layer.applyMaximum(1) # Do we need this?
-
     return layer
 
 

--- a/proxyshop/kivy/console.kv
+++ b/proxyshop/kivy/console.kv
@@ -169,7 +169,7 @@
         text_size: self.size
         halign: "left"
         valign: "center"
-        size_hint: (.75, 1)
+        size_hint: (.55, 1)
         markup: True
     Label:
         id: status
@@ -181,6 +181,14 @@
         size_hint: (.10, 1)
         markup: True
     BoxLayout:
+        id: mark_updated
+        size_hint: (.20, 1)
+        HoverButton:
+            options: ["Mark Updated"]
+            text: "Mark Updated"
+            font_size: 18
+            on_release: ak.start(entry.mark_updated())
+    BoxLayout:
         id: download
         size_hint: (.15, 1)
         HoverButton:
@@ -188,18 +196,6 @@
             text: "Download"
             font_size: 20
             on_release: ak.start(entry.download_update(self.parent))
-
-<Authenticator>:
-    title: "You need to Authenticate with Google Drive"
-    size_hint: (.50,.25)
-    auto_dismiss: True
-    BoxLayout:
-        Label:
-            id: response
-            text_autoupdate: True
-            markup: True
-            font_size: 24
-            text: "[b]Authenticating...[/b]"
 
 <TestApp>:
     id: test_app

--- a/proxyshop/layouts.py
+++ b/proxyshop/layouts.py
@@ -359,7 +359,7 @@ class BaseLayout:
         """
         Set the card's class (finer grained than layout). Used when selecting a template.
         """
-        if self.default_class == con.transform_front_class and self.card['front']:
+        if self.default_class == con.transform_front_class and not self.card['front']:
             if "Land" in self.type_line: return con.ixalan_class
             return con.transform_back_class
         elif self.default_class == con.mdfc_front_class and not self.card['front']:

--- a/proxyshop/layouts.py
+++ b/proxyshop/layouts.py
@@ -8,7 +8,7 @@ from typing import Optional, Match
 from proxyshop.constants import con
 from proxyshop.settings import cfg
 from proxyshop import scryfall as scry
-from proxyshop import frame_logic
+from proxyshop.frame_logic import select_frame_layers
 
 
 class BasicLand:
@@ -41,23 +41,23 @@ class BasicLand:
     def __str__(self):
         return f"{self.name} [{self.set}]"
 
-    @cached_property
+    @property
     def is_creature(self):
         return False
 
-    @cached_property
+    @property
     def is_land(self):
         return True
 
-    @cached_property
+    @property
     def is_nyx(self):
         return False
 
-    @cached_property
+    @property
     def is_companion(self):
         return False
 
-    @cached_property
+    @property
     def is_legendary(self):
         return False
 
@@ -149,9 +149,7 @@ class BaseLayout:
 
     @cached_property
     def mana_cost(self) -> Optional[str]:
-        if 'mana_cost' in self.card:
-            return self.card['mana_cost']
-        return
+        return self.card.get('mana_cost', None)
 
     @cached_property
     def oracle_text(self) -> str:
@@ -238,13 +236,13 @@ class BaseLayout:
     @cached_property
     def card_count(self) -> Optional[str]:
         # Select the best available card count
-        if 'printed_size' in self.scryfall and self.scryfall['printed_size'] > int(self.collector_number):
+        if 'printed_size' in self.scryfall and int(self.scryfall['printed_size']) > int(self.collector_number):
             cc = self.scryfall['printed_size']
-        elif 'baseSetSize' in self.mtgset and self.mtgset['baseSetSize'] > int(self.collector_number):
+        elif 'baseSetSize' in self.mtgset and int(self.mtgset['baseSetSize']) > int(self.collector_number):
             cc = self.mtgset['baseSetSize']
-        elif 'totalSetSize' in self.mtgset and self.mtgset['totalSetSize'] > int(self.collector_number):
+        elif 'totalSetSize' in self.mtgset and int(self.mtgset['totalSetSize']) > int(self.collector_number):
             cc = self.mtgset['totalSetSize']
-        elif 'card_count' in self.scryfall and self.scryfall['card_count'] > int(self.collector_number):
+        elif 'card_count' in self.scryfall and int(self.scryfall['card_count']) > int(self.collector_number):
             cc = self.scryfall['card_count']
         else:
             return
@@ -326,13 +324,7 @@ class BaseLayout:
 
     @cached_property
     def frame(self) -> dict:
-        return frame_logic.select_frame_layers(
-            self.mana_cost,
-            self.type_line_raw,
-            self.oracle_text_raw,
-            self.color_identity,
-            self.color_indicator
-        )
+        return select_frame_layers(self.card)
 
     @cached_property
     def twins(self) -> str:
@@ -370,7 +362,10 @@ class BaseLayout:
             return con.mutate_class
         elif "Miracle" in self.frame_effects:
             return con.miracle_class
-        # elif "Snow" in self.card['type_line']:  # frame_effects doesn't contain "snow" for pre-KHM snow cards
+        elif "Prototype" in self.keywords:
+            return con.prototype_class
+        # elif "Snow" in self.card['type_line']:
+        # frame_effects doesn't contain "snow" for pre-KHM snow cards
         #    return con.snow_class
         return self.default_class
 
@@ -488,33 +483,14 @@ class ModalDoubleFacedLayout (BaseLayout):
         return text
 
     @cached_property
-    def color_indicator_other(self) -> Optional[str]:
-        if 'color_indicator' in self.other_face:
-            return self.other_face['color_indicator']
-        return
-
-    @cached_property
-    def color_identity_other(self) -> Optional[list]:
-        if 'color_identity' in self.other_face:
-            return self.other_face['color_identity']
-        return
-
-    @cached_property
     def other_face_twins(self) -> str:
-        return frame_logic.select_frame_layers(
-            self.other_face['mana_cost'],
-            self.other_face['type_line'],
-            self.other_face['oracle_text'],
-            self.color_identity_other,
-            self.color_indicator_other)['twins']
+        return select_frame_layers(self.other_face)['twins']
 
     @cached_property
     def other_face_left(self) -> str:
-        if self.lang != "EN" and 'printed_text' in self.other_face:
-            other_face_type_line_split = self.other_face['printed_type_line'].split(" ")
-        else:
-            other_face_type_line_split = self.other_face['type_line'].split(" ")
-        return other_face_type_line_split[len(other_face_type_line_split) - 1]
+        if self.lang != "EN" and 'printed_type_line' in self.other_face:
+            return self.other_face['printed_type_line'].split(" ")[-1]
+        return self.other_face['type_line'].split(" ")[-1]
 
     @cached_property
     def other_face_right(self) -> str:

--- a/proxyshop/plugins/MrTeferi/templates.py
+++ b/proxyshop/plugins/MrTeferi/templates.py
@@ -94,16 +94,16 @@ class KaldheimTemplate (temp.NormalTemplate):
     @cached_property
     def pt_layer(self) -> Optional[ArtLayer]:
         if "Vehicle" in self.layout.type_line:
-            return psd.getLayer("Vehicle", con.layers['PT_BOX'])
-        return psd.getLayer(self.twins, con.layers['PT_BOX'])
+            return psd.getLayer("Vehicle", con.layers.PT_BOX)
+        return psd.getLayer(self.twins, con.layers.PT_BOX)
 
     @cached_property
     def pinlines_layer(self) -> Optional[ArtLayer]:
         if self.is_land:
-            return psd.getLayer(self.pinlines, con.layers['LAND_PINLINES_TEXTBOX'])
+            return psd.getLayer(self.pinlines, con.layers.LAND_PINLINES_TEXTBOX)
         if "Vehicle" in self.layout.type_line:
-            return psd.getLayer("Vehicle", con.layers['PINLINES_TEXTBOX'])
-        return psd.getLayer(self.pinlines, con.layers['PINLINES_TEXTBOX'])
+            return psd.getLayer("Vehicle", con.layers.PINLINES_TEXTBOX)
+        return psd.getLayer(self.pinlines, con.layers.PINLINES_TEXTBOX)
 
 
 class CrimsonFangTemplate (temp.NormalTemplate):
@@ -128,10 +128,10 @@ class CrimsonFangTemplate (temp.NormalTemplate):
     def pinlines_layer(self) -> Optional[ArtLayer]:
         # Pinlines
         if self.is_land:
-            return psd.getLayer(self.pinlines, con.layers['LAND_PINLINES_TEXTBOX'])
+            return psd.getLayer(self.pinlines, con.layers.LAND_PINLINES_TEXTBOX)
         if self.name_shifted and not self.is_front:
-            return psd.getLayer(self.pinlines, "MDFC " + con.layers['PINLINES_TEXTBOX'])
-        return psd.getLayer(self.pinlines, con.layers['PINLINES_TEXTBOX'])
+            return psd.getLayer(self.pinlines, "MDFC " + con.layers.PINLINES_TEXTBOX)
+        return psd.getLayer(self.pinlines, con.layers.PINLINES_TEXTBOX)
 
     @cached_property
     def transform_icon(self) -> Optional[ArtLayer]:
@@ -225,7 +225,7 @@ class MaleMPCTemplate (temp.NormalTemplate):
         psd.content_fill_empty_area(self.art_layer)
 
     def enable_crown(self):
-        psd.enable_mask(psd.getLayer(con.layers['SHADOWS']))
+        psd.enable_mask(psd.getLayer(con.layers.SHADOWS))
         psd.enable_mask(self.pinlines_layer.parent)
         super().enable_crown()
 
@@ -246,7 +246,7 @@ class PromoClassicTemplate (temp.NormalClassicTemplate):
         super().enable_frame_layers()
 
         # Add the promo star
-        psd.getLayer("Promo Star", con.layers['TEXT_AND_ICONS']).visible = True
+        psd.getLayer("Promo Star", con.layers.TEXT_AND_ICONS).visible = True
 
 
 class ColorshiftedTemplate (temp.NormalTemplate):
@@ -279,9 +279,9 @@ class ColorshiftedTemplate (temp.NormalTemplate):
         if self.is_creature:
             # Check if vehicle
             if "Vehicle" in self.layout.type_line:
-                return psd.getLayer("Vehicle", con.layers['PT_BOX'])
-            return psd.getLayer(self.twins, con.layers['PT_BOX'])
-        return psd.getLayerSet(con.layers['PT_BOX'])
+                return psd.getLayer("Vehicle", con.layers.PT_BOX)
+            return psd.getLayer(self.twins, con.layers.PT_BOX)
+        return psd.getLayerSet(con.layers.PT_BOX)
 
     @property
     def is_nyx(self) -> bool:
@@ -329,7 +329,7 @@ class BasicLandDarkMode (temp.BasicLandTemplate):
 
     def collector_info(self):
         # Collector info only has artist
-        psd.replace_text(psd.getLayer(con.layers['ARTIST'], self.legal_layer), "Artist", self.layout.artist)
+        psd.replace_text(psd.getLayer(con.layers.ARTIST, self.legal_layer), "Artist", self.layout.artist)
 
     def load_artwork(self):
         super().load_artwork()

--- a/proxyshop/plugins/SilvanMTG/templates.py
+++ b/proxyshop/plugins/SilvanMTG/templates.py
@@ -28,10 +28,10 @@ class SilvanExtendedTemplate (temp.NormalTemplate):
     def background_layer(self) -> Optional[ArtLayer]:
         # Background
         if self.is_nyx:
-            return psd.getLayer(self.background, con.layers['NYX'])
+            return psd.getLayer(self.background, con.layers.NYX)
         if self.background == "Colorless":
             return
-        return psd.getLayer(self.background, con.layers['BACKGROUND'])
+        return psd.getLayer(self.background, con.layers.BACKGROUND)
 
     def load_artwork(self):
         super().load_artwork()
@@ -50,7 +50,7 @@ class SilvanMDFCBackTemplate (temp.MDFCBackTemplate):
     Silvan extended template modified for MDFC
     """
     template_file_name = "SilvanMTG/extended-mdfc-back"
-    dfc_layer_group = con.layers['MDFC_BACK']
+    dfc_layer_group = con.layers.MDFC_BACK
     template_suffix = "Extended"
 
     def __init__(self, layout):
@@ -69,5 +69,5 @@ class SilvanMDFCFrontTemplate (SilvanMDFCBackTemplate):
     Silvan extended template modified for MDFC
     """
     template_file_name = "SilvanMTG/extended-mdfc-front"
-    dfc_layer_group = con.layers['MDFC_FRONT']
+    dfc_layer_group = con.layers.MDFC_FRONT
     template_suffix = "Extended"

--- a/proxyshop/scryfall.py
+++ b/proxyshop/scryfall.py
@@ -4,6 +4,8 @@ FUNCTIONS THAT INTERACT WITH SCRYFALL
 import os
 import time
 import json
+from shutil import copyfileobj
+
 import requests
 from typing import Optional, Union
 from urllib import request, parse
@@ -143,16 +145,18 @@ def card_scan(img_url: str) -> Optional[str]:
     @return: Filename of the saved image.
     """
     try:
-        request.urlretrieve(img_url, con.scryfall_scan_path)
-        if not cfg.dev_mode:
-            console.update(f"Downloaded Scryfall scan!")
+        print(img_url)
+        r = requests.get(img_url, stream=True)
+        with open(con.scryfall_scan_path, 'wb') as f:
+            copyfileobj(r.raw, f)
+            if not cfg.dev_mode:
+                console.update(f"Downloaded Scryfall scan!")
+            return f.name
     except Exception as e:
         # HTTP request failed
         if not cfg.dev_mode:
             console.update(f"Couldn't retrieve scryfall image scan! Continuing without it.", e)
         return
-    with open(con.scryfall_scan_path, encoding="utf-8") as file:
-        return file.name
 
 
 def add_meld_info(card_json: dict) -> dict:

--- a/proxyshop/symbols.json
+++ b/proxyshop/symbols.json
@@ -564,5 +564,6 @@
             "rarity": false,
             "reference": true
         }
-    ]
+    ],
+    "BOT": "\uE99E"
 }

--- a/proxyshop/templates.json
+++ b/proxyshop/templates.json
@@ -42,6 +42,9 @@
 	"miracle": {
 		"Normal": "MiracleTemplate"
 	},
+	"prototype": {
+		"Normal": "PrototypeTemplate"
+	},
 	"planeswalker": {
 		"Normal": "PlaneswalkerTemplate",
 		"Extended": "PlaneswalkerExtendedTemplate"

--- a/proxyshop/templates.py
+++ b/proxyshop/templates.py
@@ -385,6 +385,10 @@ class BaseTemplate:
         # Generate the expansion symbol
         self.create_expansion_symbol()
 
+    @property
+    def expansion_symbol_anchor(self) -> ps.AnchorPosition:
+        return ps.AnchorPosition.MiddleRight
+
     def create_expansion_symbol(self, centered=False):
         """
         Builds the expansion symbol
@@ -418,7 +422,7 @@ class BaseTemplate:
 
         # Size to fit reference?
         if cfg.auto_symbol_size:
-            psd.frame_layer(symbol_layer, ref_layer, ps.AnchorPosition.MiddleRight, True, centered)
+            psd.frame_layer(symbol_layer, ref_layer, self.expansion_symbol_anchor, True, centered)
 
         def apply_rarity(layer):
             # Apply rarity gradient to this layer

--- a/proxyshop/templates.py
+++ b/proxyshop/templates.py
@@ -152,26 +152,28 @@ class BaseTemplate:
         # Set the active layer
         self.docref.activeLayer = value
 
+    @property
+    def art_reference(self) -> str:
+        return con.layers.ART_FRAME
+
     @cached_property
     def art_reference_layer(self):
         # Select a main reference layer
-        if not hasattr(self, 'art_reference'):
+        if isinstance(self.art_reference, ArtLayer):
             # Art reference not given
-            layer = psd.getLayer(con.layers['ART_FRAME'])
-        elif isinstance(self.art_reference, str):
-            # Art reference was given as a layer name
-            layer = psd.getLayer(self.art_reference)
-        else:
-            # Art reference was given as a layer
             layer = self.art_reference
+        else:
+            layer = psd.getLayer(self.art_reference)
+            if not layer:
+                psd.getLayer(con.layers.ART_FRAME)
 
         # Check if we can change to fullart reference
-        if "Full Art" and "Fullart" not in str(layer.name):
+        if not any(map(str(layer.name).__contains__, ["Full Art", "Fullart"])):
             # Auto detect full art image
             with Image.open(self.layout.filename) as image:
                 width, height = image.size
             if height > (width * 1.2):
-                fa_frame = psd.getLayer(con.layers['FULL_ART_FRAME'])
+                fa_frame = psd.getLayer(con.layers.FULL_ART_FRAME)
                 if fa_frame:
                     return fa_frame
         return layer
@@ -197,7 +199,7 @@ class BaseTemplate:
     @cached_property
     def legal_layer(self) -> Optional[LayerSet]:
         # Legal group
-        return psd.getLayerSet(con.layers['LEGAL'])
+        return psd.getLayerSet(con.layers.LEGAL)
 
     @cached_property
     def creator_layer(self) -> Optional[ArtLayer]:
@@ -207,49 +209,49 @@ class BaseTemplate:
     @cached_property
     def text_layers(self) -> Optional[LayerSet]:
         # Text and icon group
-        return psd.getLayerSet(con.layers['TEXT_AND_ICONS'])
+        return psd.getLayerSet(con.layers.TEXT_AND_ICONS)
 
     @cached_property
     def text_layer_name(self) -> Optional[ArtLayer]:
         # CARD NAME
         if self.name_shifted:
-            psd.getLayer(con.layers['NAME'], self.text_layers).visible = False
-            name = psd.getLayer(con.layers['NAME_SHIFT'], self.text_layers)
+            psd.getLayer(con.layers.NAME, self.text_layers).visible = False
+            name = psd.getLayer(con.layers.NAME_SHIFT, self.text_layers)
             name.visible = True
             return name
-        return psd.getLayer(con.layers['NAME'], self.text_layers)
+        return psd.getLayer(con.layers.NAME, self.text_layers)
 
     @cached_property
     def text_layer_mana(self) -> Optional[ArtLayer]:
         # CARD MANA COST
-        return psd.getLayer(con.layers['MANA_COST'], self.text_layers)
+        return psd.getLayer(con.layers.MANA_COST, self.text_layers)
 
     @cached_property
     def text_layer_type(self) -> Optional[ArtLayer]:
         # CARD TYPELINE
         if self.type_line_shifted:
-            psd.getLayer(con.layers['TYPE_LINE'], self.text_layers).visible = False
-            typeline = psd.getLayer(con.layers['TYPE_LINE_SHIFT'], self.text_layers)
+            psd.getLayer(con.layers.TYPE_LINE, self.text_layers).visible = False
+            typeline = psd.getLayer(con.layers.TYPE_LINE_SHIFT, self.text_layers)
             typeline.visible = True
             return typeline
-        return psd.getLayer(con.layers['TYPE_LINE'], self.text_layers)
+        return psd.getLayer(con.layers.TYPE_LINE, self.text_layers)
 
     @cached_property
     def text_layer_rules(self) -> Optional[ArtLayer]:
         # CARD RULES TEXT
         if self.is_creature:
-            rules_text = psd.getLayer(con.layers['RULES_TEXT_CREATURE'], self.text_layers)
+            rules_text = psd.getLayer(con.layers.RULES_TEXT_CREATURE, self.text_layers)
             rules_text.visible = True
             return rules_text
         # Noncreature card - use the normal rules text layer and disable the p/t layer
         if self.text_layer_pt:
             self.text_layer_pt.visible = False
-        return psd.getLayer(con.layers['RULES_TEXT_NONCREATURE'], self.text_layers)
+        return psd.getLayer(con.layers.RULES_TEXT_NONCREATURE, self.text_layers)
 
     @cached_property
     def text_layer_pt(self) -> Optional[ArtLayer]:
         # CARD POWER/TOUGHNESS
-        return psd.getLayer(con.layers['POWER_TOUGHNESS'], self.text_layers)
+        return psd.getLayer(con.layers.POWER_TOUGHNESS, self.text_layers)
 
     """
     FRAME LAYERS
@@ -278,41 +280,41 @@ class BaseTemplate:
     @cached_property
     def twins_layer(self) -> Optional[ArtLayer]:
         # Twins
-        return psd.getLayer(self.twins, con.layers['TWINS'])
+        return psd.getLayer(self.twins, con.layers.TWINS)
 
     @cached_property
     def pinlines_layer(self) -> Optional[ArtLayer]:
         # Pinlines
         if self.is_land:
-            return psd.getLayer(self.pinlines, con.layers['LAND_PINLINES_TEXTBOX'])
-        return psd.getLayer(self.pinlines, con.layers['PINLINES_TEXTBOX'])
+            return psd.getLayer(self.pinlines, con.layers.LAND_PINLINES_TEXTBOX)
+        return psd.getLayer(self.pinlines, con.layers.PINLINES_TEXTBOX)
 
     @cached_property
     def background_layer(self) -> Optional[ArtLayer]:
         # Background
         if self.is_nyx:
-            return psd.getLayer(self.background, con.layers['NYX'])
-        return psd.getLayer(self.background, con.layers['BACKGROUND'])
+            return psd.getLayer(self.background, con.layers.NYX)
+        return psd.getLayer(self.background, con.layers.BACKGROUND)
 
     @cached_property
     def color_indicator_layer(self) -> Optional[ArtLayer]:
         # Color Indicator
-        return psd.getLayer(self.pinlines, con.layers['COLOR_INDICATOR'])
+        return psd.getLayer(self.pinlines, con.layers.COLOR_INDICATOR)
 
     @cached_property
     def crown_layer(self) -> Optional[ArtLayer]:
         # Legendary Crown
-        return psd.getLayer(self.pinlines, con.layers['LEGENDARY_CROWN'])
+        return psd.getLayer(self.pinlines, con.layers.LEGENDARY_CROWN)
 
     @cached_property
     def pt_layer(self) -> Optional[ArtLayer]:
         # Power/Toughness box
-        return psd.getLayer(self.twins, con.layers['PT_BOX'])
+        return psd.getLayer(self.twins, con.layers.PT_BOX)
 
     @cached_property
     def companion_layer(self) -> Optional[ArtLayer]:
         # Companion inner crown
-        return psd.getLayer(self.pinlines, con.layers['COMPANION'])
+        return psd.getLayer(self.pinlines, con.layers.COMPANION)
 
     @property
     def expansion_symbol(self) -> Optional[ArtLayer]:
@@ -343,7 +345,7 @@ class BaseTemplate:
         if all([self.layout.collector_number, self.layout.rarity, cfg.real_collector]):
 
             # Reveal collector group, hide old layers
-            collector_layer = psd.getLayerSet(con.layers['COLLECTOR'], con.layers['LEGAL'])
+            collector_layer = psd.getLayerSet(con.layers.COLLECTOR, con.layers.LEGAL)
             collector_layer.visible = True
             psd.getLayer("Artist", self.legal_layer).visible = False
             psd.getLayer("Set", self.legal_layer).visible = False
@@ -351,8 +353,8 @@ class BaseTemplate:
             except AttributeError: pass
 
             # Get the collector layers
-            collector_top = psd.getLayer(con.layers['TOP_LINE'], collector_layer).textItem
-            collector_bottom = psd.getLayer(con.layers['BOTTOM_LINE'], collector_layer)
+            collector_top = psd.getLayer(con.layers.TOP_LINE, collector_layer).textItem
+            collector_bottom = psd.getLayer(con.layers.BOTTOM_LINE, collector_layer)
 
             # Fill in language if needed
             if self.layout.lang != "en":
@@ -365,14 +367,14 @@ class BaseTemplate:
             else:
                 collector_top.contents = \
                     f"{self.layout.collector_number} {self.layout.rarity_letter}"
-            psd.replace_text(collector_bottom, "SET", str(self.layout.set))
+            psd.replace_text(collector_bottom, "SET", self.layout.set)
             psd.replace_text(collector_bottom, "Artist", self.layout.artist)
 
         else:
 
             # Layers we need
             set_layer = psd.getLayer("Set", self.legal_layer)
-            artist_layer = psd.getLayer(con.layers['ARTIST'], self.legal_layer)
+            artist_layer = psd.getLayer(con.layers.ARTIST, self.legal_layer)
 
             # Fill in language if needed
             if self.layout.lang != "en":
@@ -407,8 +409,8 @@ class BaseTemplate:
             rarity = con.rarity_mythic
 
         # Starting symbol, reference, and rarity layers
-        symbol_layer = psd.getLayer(con.layers['EXPANSION_SYMBOL'], self.text_layers)
-        ref_layer = psd.getLayer(con.layers['EXPANSION_REFERENCE'], self.text_layers)
+        symbol_layer = psd.getLayer(con.layers.EXPANSION_SYMBOL, self.text_layers)
+        ref_layer = psd.getLayer(con.layers.EXPANSION_REFERENCE, self.text_layers)
         rarity_layer = psd.getLayer(rarity, self.text_layers)
         current_layer = symbol_layer
 
@@ -793,8 +795,8 @@ class NormalTemplate (StarterTemplate):
     def art_reference(self) -> str:
         # If colorless, use fullart
         if self.is_colorless:
-            return con.layers['FULL_ART_FRAME']
-        return con.layers['ART_FRAME']
+            return con.layers.FULL_ART_FRAME
+        return con.layers.ART_FRAME
 
     """
     METHODS
@@ -813,10 +815,10 @@ class NormalTemplate (StarterTemplate):
                     layer = self.text_layer_rules,
                     contents = self.layout.oracle_text,
                     flavor = self.layout.flavor_text,
-                    reference = psd.getLayer(con.layers['TEXTBOX_REFERENCE'], self.text_layers),
-                    divider = psd.getLayer(con.layers['DIVIDER'], self.text_layers),
-                    pt_reference = psd.getLayer(con.layers['PT_REFERENCE'], self.text_layers),
-                    pt_top_reference = psd.getLayer(con.layers['PT_TOP_REFERENCE'], self.text_layers),
+                    reference = psd.getLayer(con.layers.TEXTBOX_REFERENCE, self.text_layers),
+                    divider = psd.getLayer(con.layers.DIVIDER, self.text_layers),
+                    pt_reference = psd.getLayer(con.layers.PT_REFERENCE, self.text_layers),
+                    pt_top_reference = psd.getLayer(con.layers.PT_TOP_REFERENCE, self.text_layers),
                     centered = self.is_centered
                 )
             ])
@@ -828,8 +830,8 @@ class NormalTemplate (StarterTemplate):
                     layer = self.text_layer_rules,
                     contents = self.layout.oracle_text,
                     flavor = self.layout.flavor_text,
-                    reference = psd.getLayer(con.layers['TEXTBOX_REFERENCE'], self.text_layers),
-                    divider = psd.getLayer(con.layers['DIVIDER'], self.text_layers),
+                    reference = psd.getLayer(con.layers.TEXTBOX_REFERENCE, self.text_layers),
+                    divider = psd.getLayer(con.layers.DIVIDER, self.text_layers),
                     centered = self.is_centered
                 )
             )
@@ -865,8 +867,8 @@ class NormalTemplate (StarterTemplate):
         Enable the Legendary crown
         """
         self.crown_layer.visible = True
-        psd.getLayer(con.layers['NORMAL_BORDER'], con.layers['BORDER']).visible = False
-        psd.getLayer(con.layers['LEGENDARY_BORDER'], con.layers['BORDER']).visible = True
+        psd.getLayer(con.layers.NORMAL_BORDER, con.layers.BORDER).visible = False
+        psd.getLayer(con.layers.LEGENDARY_BORDER, con.layers.BORDER).visible = True
 
         # Nyx/Companion: Enable the hollow crown shadow and layer mask on crown, pinlines, and shadows
         if self.is_nyx or self.is_companion:
@@ -881,11 +883,11 @@ class NormalTemplate (StarterTemplate):
         Enable the hollow legendary crown for this card given layer groups for the crown and pinlines.
         """
         if not shadows:
-            shadows = psd.getLayer(con.layers['SHADOWS'])
+            shadows = psd.getLayer(con.layers.SHADOWS)
         psd.enable_mask(self.crown_layer.parent)
         psd.enable_mask(self.pinlines_layer.parent)
         psd.enable_mask(shadows)
-        psd.getLayer(con.layers['HOLLOW_CROWN_SHADOW']).visible = True
+        psd.getLayer(con.layers.HOLLOW_CROWN_SHADOW).visible = True
 
 
 class NormalClassicTemplate (StarterTemplate):
@@ -901,7 +903,11 @@ class NormalClassicTemplate (StarterTemplate):
 
     @cached_property
     def text_layer_rules(self) -> Optional[ArtLayer]:
-        return psd.getLayer(con.layers['RULES_TEXT'], self.text_layers)
+        return psd.getLayer(con.layers.RULES_TEXT, self.text_layers)
+
+    @property
+    def type_line_shifted(self) -> bool:
+        return False
 
     def rules_text_and_pt_layers(self):
 
@@ -911,9 +917,9 @@ class NormalClassicTemplate (StarterTemplate):
 
         # Text reference and rules text
         if self.is_land:
-            reference_layer = psd.getLayer(con.layers['TEXTBOX_REFERENCE_LAND'], self.text_layers)
+            reference_layer = psd.getLayer(con.layers.TEXTBOX_REFERENCE_LAND, self.text_layers)
         else:
-            reference_layer = psd.getLayer(con.layers['TEXTBOX_REFERENCE'], self.text_layers)
+            reference_layer = psd.getLayer(con.layers.TEXTBOX_REFERENCE, self.text_layers)
 
         # Add rules text
         self.text.append(
@@ -923,7 +929,7 @@ class NormalClassicTemplate (StarterTemplate):
                 flavor = self.layout.flavor_text,
                 centered = self.is_centered,
                 reference = reference_layer,
-                divider = psd.getLayer(con.layers['DIVIDER'], self.text_layers)
+                divider = psd.getLayer(con.layers.DIVIDER, self.text_layers)
             )
         )
 
@@ -942,9 +948,9 @@ class NormalClassicTemplate (StarterTemplate):
 
         # Simple one image background, Land or Nonland
         if self.is_land:
-            psd.getLayer(self.pinlines, con.layers['LAND']).visible = True
+            psd.getLayer(self.pinlines, con.layers.LAND).visible = True
         else:
-            psd.getLayer(self.background, con.layers['NONLAND']).visible = True
+            psd.getLayer(self.background, con.layers.NONLAND).visible = True
 
 
 """
@@ -987,7 +993,7 @@ class WomensDayTemplate (NormalTemplate):
 
     @cached_property
     def art_reference_layer(self) -> ArtLayer:
-        return psd.getLayer(con.layers['FULL_ART_FRAME'])
+        return psd.getLayer(con.layers.FULL_ART_FRAME)
 
     @property
     def is_nyx(self) -> bool:
@@ -999,13 +1005,13 @@ class WomensDayTemplate (NormalTemplate):
 
     @property
     def background_layer(self) -> Optional[ArtLayer]:
-        return None
+        return
 
     @cached_property
     def crown_layer(self) -> Optional[ArtLayer]:
         # On first access, enable pinlines mask
         psd.enable_mask(self.pinlines_layer.parent)
-        return psd.getLayer(self.pinlines, con.layers['LEGENDARY_CROWN'])
+        return psd.getLayer(self.pinlines, con.layers.LEGENDARY_CROWN)
 
 
 class StargazingTemplate (NormalTemplate):
@@ -1100,15 +1106,15 @@ class ExpeditionTemplate (NormalTemplate):
 
     @cached_property
     def text_layer_rules(self) -> Optional[ArtLayer]:
-        return psd.getLayer(con.layers['RULES_TEXT_NONCREATURE'], self.text_layers)
+        return psd.getLayer(con.layers.RULES_TEXT_NONCREATURE, self.text_layers)
 
     @cached_property
     def background_layer(self) -> Optional[ArtLayer]:
-        return None
+        return
 
     @cached_property
     def color_indicator_layer(self) -> Optional[ArtLayer]:
-        return None
+        return
 
     @property
     def is_land(self) -> bool:
@@ -1118,8 +1124,8 @@ class ExpeditionTemplate (NormalTemplate):
         # legendary crown
         psd.enable_mask(self.pinlines_layer.parent)
         self.crown_layer.visible = True
-        psd.getLayer(con.layers['NORMAL_BORDER'], con.layers['BORDER']).visible = False
-        psd.getLayer(con.layers['LEGENDARY_BORDER'], con.layers['BORDER']).visible = True
+        psd.getLayer(con.layers.NORMAL_BORDER, con.layers.BORDER).visible = False
+        psd.getLayer(con.layers.LEGENDARY_BORDER, con.layers.BORDER).visible = True
 
 
 class SnowTemplate (NormalTemplate):
@@ -1168,12 +1174,12 @@ class TransformBackTemplate (NormalTemplate):
     Template for the back faces of transform cards.
     """
     template_file_name = "tf-back.psd"
-    dfc_layer_group = con.layers['TF_BACK']
+    dfc_layer_group = con.layers.TF_BACK
 
     @cached_property
     def transform_icon(self) -> Optional[ArtLayer]:
         return psd.getLayer(self.layout.transform_icon, psd.getLayerSet(
-            self.dfc_layer_group, con.layers['TEXT_AND_ICONS'])
+            self.dfc_layer_group, con.layers.TEXT_AND_ICONS)
         )
 
     def enable_frame_layers(self):
@@ -1183,7 +1189,7 @@ class TransformBackTemplate (NormalTemplate):
 
     def basic_text_layers(self):
         # For eldrazi card, set the color of the rules text, type line, and power/toughness to black
-        if self.layout.transform_icon == con.layers['MOON_ELDRAZI_DFC']:
+        if self.layout.transform_icon == con.layers.MOON_ELDRAZI_DFC:
             self.text_layer_name.color = psd.rgb_black()
             self.text_layer_type.color = psd.rgb_black()
             self.text_layer_pt.color = psd.rgb_black()
@@ -1195,18 +1201,18 @@ class TransformFrontTemplate (TransformBackTemplate):
     Template for the front faces of transform cards.
     """
     template_file_name = "tf-front.psd"
-    dfc_layer_group = con.layers['TF_FRONT']
+    dfc_layer_group = con.layers.TF_FRONT
 
     @cached_property
     def text_layer_rules(self) -> Optional[ArtLayer]:
         if self.is_creature:
             if self.other_face_is_creature:
-                return psd.getLayer(con.layers['RULES_TEXT_CREATURE_FLIP'], self.text_layers)
-            return psd.getLayer(con.layers['RULES_TEXT_CREATURE'], self.text_layers)
+                return psd.getLayer(con.layers.RULES_TEXT_CREATURE_FLIP, self.text_layers)
+            return psd.getLayer(con.layers.RULES_TEXT_CREATURE, self.text_layers)
         self.text_layer_pt.visible = False
         if self.other_face_is_creature:
-            return psd.getLayer(con.layers['RULES_TEXT_NONCREATURE_FLIP'], self.text_layers)
-        return psd.getLayer(con.layers['RULES_TEXT_NONCREATURE'], self.text_layers)
+            return psd.getLayer(con.layers.RULES_TEXT_NONCREATURE_FLIP, self.text_layers)
+        return psd.getLayer(con.layers.RULES_TEXT_NONCREATURE, self.text_layers)
 
     def rules_text_and_pt_layers(self):
 
@@ -1214,7 +1220,7 @@ class TransformFrontTemplate (TransformBackTemplate):
         if self.other_face_is_creature:
             self.text.append(
                 text_classes.TextField(
-                    layer=psd.getLayer(con.layers['FLIPSIDE_POWER_TOUGHNESS'], con.layers['TEXT_AND_ICONS']),
+                    layer=psd.getLayer(con.layers.FLIPSIDE_POWER_TOUGHNESS, con.layers.TEXT_AND_ICONS),
                     contents=str(self.layout.other_face_power) + "/" + str(self.layout.other_face_toughness)
                 )
             )
@@ -1265,7 +1271,7 @@ class MDFCBackTemplate (NormalTemplate):
     Template for the back faces of modal double faced cards.
     """
     template_file_name = "mdfc-back"
-    dfc_layer_group = con.layers['MDFC_BACK']
+    dfc_layer_group = con.layers.MDFC_BACK
 
     @cached_property
     def mdfc_group(self) -> Optional[LayerSet]:
@@ -1273,11 +1279,11 @@ class MDFCBackTemplate (NormalTemplate):
 
     @cached_property
     def text_layer_mdfc_left(self) -> Optional[ArtLayer]:
-        return psd.getLayer(con.layers['LEFT'], self.mdfc_group)
+        return psd.getLayer(con.layers.LEFT, self.mdfc_group)
 
     @cached_property
     def text_layer_mdfc_right(self) -> Optional[ArtLayer]:
-        return psd.getLayer(con.layers['RIGHT'], self.mdfc_group)
+        return psd.getLayer(con.layers.RIGHT, self.mdfc_group)
 
     def basic_text_layers(self):
         super().basic_text_layers()
@@ -1297,9 +1303,9 @@ class MDFCBackTemplate (NormalTemplate):
 
     def enable_frame_layers(self):
         psd.getLayer(self.twins,
-                     psd.getLayerSet(con.layers['TOP'], self.mdfc_group)).visible = True
+                     psd.getLayerSet(con.layers.TOP, self.mdfc_group)).visible = True
         psd.getLayer(self.layout.other_face_twins,
-                     psd.getLayerSet(con.layers['BOTTOM'], self.mdfc_group)).visible = True
+                     psd.getLayerSet(con.layers.BOTTOM, self.mdfc_group)).visible = True
         super().enable_frame_layers()
 
 
@@ -1308,7 +1314,7 @@ class MDFCFrontTemplate (MDFCBackTemplate):
     Template for the front faces of modal double faced cards.
     """
     template_file_name = "mdfc-front"
-    dfc_layer_group = con.layers['MDFC_FRONT']
+    dfc_layer_group = con.layers.MDFC_FRONT
 
 
 """
@@ -1330,12 +1336,12 @@ class MutateTemplate (NormalTemplate):
         # Split self.oracle_text between mutate text and actual text before calling super()
         split_rules_text = layout.oracle_text.split("\n")
         layout.mutate_text = split_rules_text[0]
-        layout.oracle_text = "\n".join(split_rules_text[1:len(split_rules_text)])
+        layout.oracle_text = "\n".join(split_rules_text[1:])
         super().__init__(layout)
 
     @cached_property
     def text_layer_mutate(self) -> Optional[ArtLayer]:
-        return psd.getLayer(con.layers['MUTATE'], self.text_layers)
+        return psd.getLayer(con.layers.MUTATE, self.text_layers)
 
     def basic_text_layers(self):
         super().basic_text_layers()
@@ -1346,10 +1352,104 @@ class MutateTemplate (NormalTemplate):
                 layer = self.text_layer_mutate,
                 contents = self.layout.mutate_text,
                 flavor = self.layout.flavor_text,
-                centered = False,
-                reference = psd.getLayer(con.layers['MUTATE_REFERENCE'], self.text_layers),
+                reference = psd.getLayer(con.layers.MUTATE_REFERENCE, self.text_layers),
             )
         )
+
+
+class PrototypeTemplate (NormalTemplate):
+    """
+    A template for Prototype cards introduced in The Brothers' War. This template has a couple
+    of additional text layers for prototype text, mana cost, and power/toughness.
+    Doesn't support Nyx backgrounds or Companion crowns.
+    """
+    template_file_name = "prototype.psd"
+
+    def __init__(self, layout):
+
+        # Split self.oracle_text between prototype text and rules text
+        split_rules_text = layout.oracle_text.split("\n")
+        layout.oracle_text = "\n".join(split_rules_text[1:])
+
+        # Set up the prototype elements
+        reg = r"Prototype (.+) [\—\-] ([0-9]{0,2}/[0-9]{0,2}) \((.+)\)"
+        match = re.match(reg, split_rules_text[0])
+        self.proto_mana_cost, self.proto_pt = match[1], match[2]
+        super().__init__(layout)
+
+    @cached_property
+    def proto_color(self) -> Optional[str]:
+        for c in ['W', 'U', 'B', 'R', 'G']:
+            if c in self.proto_mana_cost:
+                return c
+        return
+
+    @cached_property
+    def proto_textbox(self) -> Optional[ArtLayer]:
+        return psd.getLayer(self.proto_color, con.layers.PROTO_TEXTBOX)
+
+    @cached_property
+    def proto_manabox(self) -> Optional[ArtLayer]:
+        if self.proto_mana_cost.count('{') == 2:
+            manabox_group = psd.getLayerSet(con.layers.PROTO_MANABOX_SMALL)
+        else:
+            manabox_group = psd.getLayerSet(con.layers.PROTO_MANABOX_MEDIUM)
+        manabox_group.visible = True
+        return psd.getLayer(self.proto_color, manabox_group)
+
+    @cached_property
+    def proto_ptbox(self) -> Optional[ArtLayer]:
+        return psd.getLayer(self.proto_color, con.layers.PROTO_PTBOX)
+
+    @cached_property
+    def text_layer_proto(self) -> Optional[ArtLayer]:
+        return psd.getLayer(con.layers.PROTO_RULES, self.text_layers)
+
+    @cached_property
+    def text_layer_proto_mana(self) -> Optional[ArtLayer]:
+        return psd.getLayer(con.layers.PROTO_MANA_COST, self.text_layers)
+
+    @cached_property
+    def text_layer_proto_pt(self) -> Optional[ArtLayer]:
+        return psd.getLayer(con.layers.PROTO_PT, self.text_layers)
+
+    def basic_text_layers(self):
+        super().basic_text_layers()
+
+        # Add prototype PT and Mana Cost
+        self.text.extend([
+            text_classes.FormattedTextField(
+                layer = self.text_layer_proto_mana,
+                contents = self.proto_mana_cost
+            ),
+            text_classes.TextField(
+                layer = self.text_layer_proto_pt,
+                contents = self.proto_pt
+            )
+        ])
+
+        # Remove reminder text if necessary
+        if cfg.remove_reminder:
+            self.text_layer_proto.textItem.size = psd.get_text_scale_factor(
+                self.text_layer_proto) * 8.93
+            self.text.append(
+                text_classes.FormattedTextArea(
+                    layer = self.text_layer_proto,
+                    contents = 'Prototype',
+                    reference = self.proto_textbox
+                )
+            )
+
+    def enable_frame_layers(self):
+        super().enable_frame_layers()
+
+        # Add prototype layers
+        if self.proto_textbox:
+            self.proto_textbox.visible = True
+        if self.proto_manabox:
+            self.proto_manabox.visible = True
+        if self.proto_ptbox:
+            self.proto_ptbox.visible = True
 
 
 class AdventureTemplate (NormalTemplate):
@@ -1365,26 +1465,26 @@ class AdventureTemplate (NormalTemplate):
         super().basic_text_layers()
 
         # Add adventure text layers
-        mana_cost = psd.getLayer(con.layers['MANA_COST_ADVENTURE'], self.text_layers)
+        mana_cost = psd.getLayer(con.layers.MANA_COST_ADVENTURE, self.text_layers)
         self.text.extend([
             text_classes.FormattedTextField(
                 layer = mana_cost,
                 contents = self.layout.adventure['mana_cost']
             ),
             text_classes.ScaledTextField(
-                layer = psd.getLayer(con.layers['NAME_ADVENTURE'], self.text_layers),
+                layer = psd.getLayer(con.layers.NAME_ADVENTURE, self.text_layers),
                 contents = self.layout.adventure['name'],
                 reference = mana_cost,
             ),
             text_classes.FormattedTextArea(
-                layer = psd.getLayer(con.layers['RULES_TEXT_ADVENTURE'], self.text_layers),
+                layer = psd.getLayer(con.layers.RULES_TEXT_ADVENTURE, self.text_layers),
                 contents = self.layout.adventure['oracle_text'],
                 flavor = "",
                 centered = False,
-                reference = psd.getLayer(con.layers['TEXTBOX_REFERENCE_ADVENTURE'], self.text_layers),
+                reference = psd.getLayer(con.layers.TEXTBOX_REFERENCE_ADVENTURE, self.text_layers),
             ),
             text_classes.TextField(
-                layer = psd.getLayer(con.layers['TYPE_LINE_ADVENTURE'], self.text_layers),
+                layer = psd.getLayer(con.layers.TYPE_LINE_ADVENTURE, self.text_layers),
                 contents = self.layout.adventure['type_line']
             )
         ])
@@ -1454,7 +1554,7 @@ class LevelerTemplate (NormalTemplate):
 
     @cached_property
     def pt_layer(self) -> Optional[ArtLayer]:
-        return psd.getLayer(self.twins, con.layers['PT_AND_LEVEL_BOXES'])
+        return psd.getLayer(self.twins, con.layers.PT_AND_LEVEL_BOXES)
 
 
 class SagaTemplate (NormalTemplate):
@@ -1469,8 +1569,8 @@ class SagaTemplate (NormalTemplate):
         super().__init__(layout)
 
         # Paste scryfall scan
-        self.active_layer = psd.getLayerSet(con.layers['TWINS'])
-        self.paste_scryfall_scan(psd.getLayer(con.layers['SCRYFALL_SCAN_FRAME']))
+        self.active_layer = psd.getLayerSet(con.layers.TWINS)
+        self.paste_scryfall_scan(psd.getLayer(con.layers.SCRYFALL_SCAN_FRAME))
 
     @property
     def is_legendary(self) -> bool:
@@ -1490,7 +1590,7 @@ class SagaTemplate (NormalTemplate):
 
     @cached_property
     def pinlines_layer(self) -> Optional[ArtLayer]:
-        return psd.getLayer(self.background, con.layers['TEXTBOX'])
+        return psd.getLayer(self.background, con.layers.TEXTBOX)
 
     def rules_text_and_pt_layers(self):
 
@@ -1510,7 +1610,7 @@ class SagaTemplate (NormalTemplate):
 
     def enable_frame_layers(self):
         super().enable_frame_layers()
-        psd.getLayer(self.pinlines, con.layers['PINLINES_AND_SAGA_STRIPE']).visible = True
+        psd.getLayer(self.pinlines, con.layers.PINLINES_AND_SAGA_STRIPE).visible = True
 
 
 """
@@ -1547,9 +1647,9 @@ class PlaneswalkerTemplate (StarterTemplate):
     def art_reference(self):
         # Name of art reference layer
         return psd.getLayer(
-            con.layers['FULL_ART_FRAME']
+            con.layers.FULL_ART_FRAME
         ) if self.is_colorless else psd.getLayer(
-            con.layers['PLANESWALKER_ART_FRAME']
+            con.layers.PLANESWALKER_ART_FRAME
         )
 
     """
@@ -1558,19 +1658,19 @@ class PlaneswalkerTemplate (StarterTemplate):
 
     @cached_property
     def text_layers(self) -> LayerSet:
-        return psd.getLayerSet(con.layers['TEXT_AND_ICONS'], self.group)
+        return psd.getLayerSet(con.layers.TEXT_AND_ICONS, self.group)
 
     @cached_property
     def ref(self) -> ArtLayer:
-        return psd.getLayer(con.layers["TEXTBOX_REFERENCE"], self.text_layers)
+        return psd.getLayer(con.layers.TEXTBOX_REFERENCE, self.text_layers)
 
     @cached_property
     def top_ref(self) -> ArtLayer:
-        return psd.getLayer(con.layers["PW_TOP_REFERENCE"], self.text_layers)
+        return psd.getLayer(con.layers.PW_TOP_REFERENCE, self.text_layers)
 
     @cached_property
     def adj_ref(self) -> ArtLayer:
-        return psd.getLayer(con.layers["PW_ADJUSTMENT_REFERENCE"], self.text_layers)
+        return psd.getLayer(con.layers.PW_ADJUSTMENT_REFERENCE, self.text_layers)
 
     """
     LAYERS
@@ -1589,7 +1689,7 @@ class PlaneswalkerTemplate (StarterTemplate):
 
     @cached_property
     def loyalty_group(self) -> LayerSet:
-        return psd.getLayerSet(con.layers['LOYALTY_GRAPHICS'])
+        return psd.getLayerSet(con.layers.LOYALTY_GRAPHICS)
 
     @property
     def ability_layers(self) -> list[ArtLayer]:
@@ -1617,19 +1717,19 @@ class PlaneswalkerTemplate (StarterTemplate):
 
     @cached_property
     def twins_layer(self) -> Optional[ArtLayer]:
-        return psd.getLayer(self.twins, psd.getLayerSet(con.layers['TWINS'], self.group))
+        return psd.getLayer(self.twins, psd.getLayerSet(con.layers.TWINS, self.group))
 
     @cached_property
     def pinlines_layer(self) -> Optional[ArtLayer]:
-        return psd.getLayer(self.pinlines, psd.getLayerSet(con.layers['PINLINES'], self.group))
+        return psd.getLayer(self.pinlines, psd.getLayerSet(con.layers.PINLINES, self.group))
 
     @cached_property
     def background_layer(self) -> Optional[ArtLayer]:
-        return psd.getLayer(self.background, psd.getLayerSet(con.layers['BACKGROUND'], self.group))
+        return psd.getLayer(self.background, psd.getLayerSet(con.layers.BACKGROUND, self.group))
 
     @cached_property
     def color_indicator_layer(self) -> Optional[ArtLayer]:
-        return psd.getLayer(self.pinlines, [self.group, con.layers['COLOR_INDICATOR']])
+        return psd.getLayer(self.pinlines, [self.group, con.layers.COLOR_INDICATOR])
 
     def basic_text_layers(self):
 
@@ -1642,19 +1742,19 @@ class PlaneswalkerTemplate (StarterTemplate):
 
                 # Determine which loyalty group to enable, and set the loyalty symbol's text
                 loyalty_graphic = psd.getLayerSet(ability[0], self.loyalty_group)
-                psd.getLayer(con.layers['COST'], loyalty_graphic).textItem.contents = ability[0:int(colon_index)]
-                ability_layer = psd.getLayer(con.layers['ABILITY_TEXT'], self.loyalty_group).duplicate()
+                psd.getLayer(con.layers.COST, loyalty_graphic).textItem.contents = ability[0:int(colon_index)]
+                ability_layer = psd.getLayer(con.layers.ABILITY_TEXT, self.loyalty_group).duplicate()
 
                 # Add text layer, shields, and colons to list
                 self.ability_layers.append(ability_layer)
                 self.shields.append(loyalty_graphic.duplicate())
-                self.colons.append(psd.getLayer(con.layers['COLON'], self.loyalty_group).duplicate())
+                self.colons.append(psd.getLayer(con.layers.COLON, self.loyalty_group).duplicate())
                 ability = ability[colon_index + 2:]
 
             else:
 
                 # Hide default ability, switch to static
-                ability_layer = psd.getLayer(con.layers['STATIC_TEXT'], self.loyalty_group).duplicate()
+                ability_layer = psd.getLayer(con.layers.STATIC_TEXT, self.loyalty_group).duplicate()
                 self.ability_layers.append(ability_layer)
                 self.shields.append(None)
                 self.colons.append(None)
@@ -1674,7 +1774,7 @@ class PlaneswalkerTemplate (StarterTemplate):
 
         # Starting loyalty
         psd.getLayer(
-            con.layers['TEXT'], [self.loyalty_group, con.layers['STARTING_LOYALTY']]
+            con.layers.TEXT, [self.loyalty_group, con.layers.STARTING_LOYALTY]
         ).textItem.contents = self.layout.loyalty
 
         # Call to super for name, type, etc
@@ -1682,8 +1782,8 @@ class PlaneswalkerTemplate (StarterTemplate):
 
     def enable_frame_layers(self):
         # Paste scryfall scan
-        self.active_layer = psd.getLayerSet(con.layers['TEXTBOX'], self.group)
-        self.paste_scryfall_scan(psd.getLayer(con.layers['SCRYFALL_SCAN_FRAME']), False, False)
+        self.active_layer = psd.getLayerSet(con.layers.TEXTBOX, self.group)
+        self.paste_scryfall_scan(psd.getLayer(con.layers.SCRYFALL_SCAN_FRAME), False, False)
         self.active_layer = self.art_layer
 
         # Enable twins, pinlines, background, color indicator
@@ -1774,7 +1874,7 @@ class PlaneswalkerTemplate (StarterTemplate):
         """
 
         # Ragged line layers
-        lines = psd.getLayerSet("Ragged Lines", [self.group, con.layers['TEXTBOX'], "Ability Dividers"])
+        lines = psd.getLayerSet("Ragged Lines", [self.group, con.layers.TEXTBOX, "Ability Dividers"])
         line1_top = psd.getLayer("Line 1 Top", lines)
         line1_bottom = psd.getLayer("Line 1 Bottom", lines)
         line1_top_ref = psd.getLayer("Line 1 Top Reference", lines)
@@ -1827,7 +1927,7 @@ class PlaneswalkerTemplate (StarterTemplate):
 
     def fill_between_ragged_lines(self, line1, line2):
         """
-        Fille are between ragged lines.
+        Fill area between ragged lines.
         """
         self.active_layer = self.docref.artLayers.add()
         self.active_layer.move(line1, ps.ElementPlacement.PlaceAfter)
@@ -1855,7 +1955,7 @@ class PlaneswalkerExtendedTemplate (PlaneswalkerTemplate):
 
     @cached_property
     def background_layer(self) -> Optional[ArtLayer]:
-        return None
+        return
 
     def enable_frame_layers(self):
         super().enable_frame_layers()
@@ -1868,7 +1968,7 @@ class PlaneswalkerMDFCBackTemplate (PlaneswalkerTemplate):
     Need to enable MDFC layers and add MDFC text.
     """
     template_file_name = "pw-mdfc-back"
-    dfc_layer_group = con.layers['MDFC_BACK']
+    dfc_layer_group = con.layers.MDFC_BACK
 
     @cached_property
     def mdfc_group(self) -> Optional[LayerSet]:
@@ -1876,16 +1976,16 @@ class PlaneswalkerMDFCBackTemplate (PlaneswalkerTemplate):
 
     @cached_property
     def text_layer_mdfc_left(self) -> Optional[ArtLayer]:
-        return psd.getLayer(con.layers['LEFT'], self.mdfc_group)
+        return psd.getLayer(con.layers.LEFT, self.mdfc_group)
 
     @cached_property
     def text_layer_mdfc_right(self) -> Optional[ArtLayer]:
-        return psd.getLayer(con.layers['RIGHT'], self.mdfc_group)
+        return psd.getLayer(con.layers.RIGHT, self.mdfc_group)
 
     @cached_property
     def text_layer_name(self) -> Optional[ArtLayer]:
         # Name is always shifted
-        return psd.getLayer(con.layers['NAME'], self.text_layers)
+        return psd.getLayer(con.layers.NAME, self.text_layers)
 
     def basic_text_layers(self):
         super().basic_text_layers()
@@ -1908,9 +2008,9 @@ class PlaneswalkerMDFCBackTemplate (PlaneswalkerTemplate):
 
         # Add special MDFC layers
         psd.getLayer(self.twins,
-                     psd.getLayerSet(con.layers['TOP'], self.mdfc_group)).visible = True
+                     psd.getLayerSet(con.layers.TOP, self.mdfc_group)).visible = True
         psd.getLayer(self.layout.other_face_twins,
-                     psd.getLayerSet(con.layers['BOTTOM'], self.mdfc_group)).visible = True
+                     psd.getLayerSet(con.layers.BOTTOM, self.mdfc_group)).visible = True
 
 
 class PlaneswalkerMDFCFrontTemplate (PlaneswalkerMDFCBackTemplate):
@@ -1918,7 +2018,7 @@ class PlaneswalkerMDFCFrontTemplate (PlaneswalkerMDFCBackTemplate):
     Template for the front faces of modal double faced Planeswalker cards.
     """
     template_file_name = "pw-mdfc-front"
-    dfc_layer_group = con.layers['MDFC_FRONT']
+    dfc_layer_group = con.layers.MDFC_FRONT
 
 
 class PlaneswalkerMDFCBackExtendedTemplate (PlaneswalkerMDFCBackTemplate):
@@ -1931,7 +2031,7 @@ class PlaneswalkerMDFCBackExtendedTemplate (PlaneswalkerMDFCBackTemplate):
 
     @cached_property
     def background_layer(self) -> Optional[ArtLayer]:
-        return None
+        return
 
     def enable_frame_layers(self):
         super().enable_frame_layers()
@@ -1948,7 +2048,7 @@ class PlaneswalkerMDFCFrontExtendedTemplate (PlaneswalkerMDFCFrontTemplate):
 
     @cached_property
     def background_layer(self) -> Optional[ArtLayer]:
-        return None
+        return
 
     def enable_frame_layers(self):
         super().enable_frame_layers()
@@ -1960,17 +2060,17 @@ class PlaneswalkerTransformBackTemplate (PlaneswalkerTemplate):
     Template for the back faces of transform cards.
     """
     template_file_name = "pw-tf-back"
-    dfc_layer_group = con.layers['TF_BACK']
+    dfc_layer_group = con.layers.TF_BACK
 
     @cached_property
     def text_layer_name(self) -> Optional[ArtLayer]:
         # Name is always shifted
-        return psd.getLayer(con.layers['NAME'], self.text_layers)
+        return psd.getLayer(con.layers.NAME, self.text_layers)
 
     @cached_property
     def text_layer_type(self) -> Optional[ArtLayer]:
         # Name is always shifted
-        return psd.getLayer(con.layers['TYPE_LINE'], self.text_layers)
+        return psd.getLayer(con.layers.TYPE_LINE, self.text_layers)
 
     @cached_property
     def transform_icon(self) -> Optional[ArtLayer]:
@@ -1987,7 +2087,7 @@ class PlaneswalkerTransformFrontTemplate (PlaneswalkerTransformBackTemplate):
     Template for the back faces of transform cards.
     """
     template_file_name = "pw-tf-front"
-    dfc_layer_group = con.layers['TF_FRONT']
+    dfc_layer_group = con.layers.TF_FRONT
 
 
 class PlaneswalkerTransformBackExtendedTemplate (PlaneswalkerTransformBackTemplate):
@@ -2000,7 +2100,7 @@ class PlaneswalkerTransformBackExtendedTemplate (PlaneswalkerTransformBackTempla
 
     @cached_property
     def background_layer(self) -> Optional[ArtLayer]:
-        return None
+        return
 
     def enable_frame_layers(self):
         super().enable_frame_layers()
@@ -2017,7 +2117,7 @@ class PlaneswalkerTransformFrontExtendedTemplate (PlaneswalkerTransformFrontTemp
 
     @cached_property
     def background_layer(self) -> Optional[ArtLayer]:
-        return None
+        return
 
     def enable_frame_layers(self):
         super().enable_frame_layers()
@@ -2041,11 +2141,11 @@ class PlanarTemplate (StarterTemplate):
 
     @cached_property
     def text_layer_static_ability(self) -> ArtLayer:
-        return psd.getLayer(con.layers['STATIC_ABILITY'], self.text_layers)
+        return psd.getLayer(con.layers.STATIC_ABILITY, self.text_layers)
 
     @cached_property
     def text_layer_chaos_ability(self) -> ArtLayer:
-        return psd.getLayer(con.layers['CHAOS_ABILITY'], self.text_layers)
+        return psd.getLayer(con.layers.CHAOS_ABILITY, self.text_layers)
 
     def basic_text_layers(self):
 
@@ -2065,7 +2165,7 @@ class PlanarTemplate (StarterTemplate):
     def rules_text_and_pt_layers(self):
 
         # Phenomenon card?
-        if self.layout.type_line == con.layers['PHENOMENON']:
+        if self.layout.type_line == con.layers.PHENOMENON:
 
             # Insert oracle text into static ability layer and disable chaos ability & layer mask on textbox
             self.text.append(
@@ -2074,8 +2174,8 @@ class PlanarTemplate (StarterTemplate):
                     contents = self.layout.oracle_text
                 )
             )
-            psd.enable_mask(psd.getLayerSet(con.layers['TEXTBOX']))
-            psd.getLayer(con.layers['CHAOS_SYMBOL'], self.text_layers).visible = False
+            psd.enable_mask(psd.getLayerSet(con.layers.TEXTBOX))
+            psd.getLayer(con.layers.CHAOS_SYMBOL, self.text_layers).visible = False
             self.text_layer_chaos_ability.visible = False
 
         else:
@@ -2096,8 +2196,8 @@ class PlanarTemplate (StarterTemplate):
     def enable_frame_layers(self):
 
         # Paste scryfall scan
-        self.active_layer = psd.getLayerSet(con.layers['TEXTBOX'])
-        self.paste_scryfall_scan(psd.getLayer(con.layers['SCRYFALL_SCAN_FRAME']), True)
+        self.active_layer = psd.getLayerSet(con.layers.TEXTBOX)
+        self.paste_scryfall_scan(psd.getLayer(con.layers.SCRYFALL_SCAN_FRAME), True)
 
 
 """
@@ -2118,7 +2218,7 @@ class BasicLandTemplate (BaseTemplate):
 
     @property
     def art_reference(self) -> str:
-        return con.layers['BASIC_ART_FRAME']
+        return con.layers.BASIC_ART_FRAME
 
     @cached_property
     def text_layers(self) -> Optional[LayerSet]:

--- a/proxyshop/text_layers.py
+++ b/proxyshop/text_layers.py
@@ -78,12 +78,21 @@ class ScaledTextField (TextField):
     A TextField which automatically scales down its font size (in 0.25 pt increments) until
     its right bound no longer overlaps with a reference layer's left bound.
     """
+    @cached_property
+    def flip_scale(self):
+        if 'flip_scale' in self.kwargs:
+            return self.kwargs['flip_scale']
+        return False
+
     def execute(self):
         super().execute()
 
         # Scale down the text layer until it doesn't overlap with a reference layer
         if self.reference:
-            ft.scale_text_right_overlap(self.layer, self.reference)
+            if self.flip_scale:
+                ft.scale_text_left_overlap(self.layer, self.reference)
+            else:
+                ft.scale_text_right_overlap(self.layer, self.reference)
 
 
 class FormattedTextField (TextField):


### PR DESCRIPTION
Included changes:
- Transition from using a dictionary to track layer names to now using a dataclass, allowing more autofill capabilities for the IDE. Constants have also been entirely rolled into the Constants class rather than pointing to outside variables.
- Huge rework to Text Layer classes, primarily the Formatted classes, major improvements to order of operations and inheritance for processing input text details like symbol indices, italicized text indices, etc.
- Rework of the select frame layers logic, giving the function more access to Scryfall data.
- New left side equivalent for scaling against overlapping object in format_text
- "Mark Updated" button added to updater popup to allow for dismissing an update after manual download.
- Removed some deprecated functions and holdover lines.
- Prototype added as a template class.
- Fixed Scryfall art scan downloading.
- Fixed a bug causing cards with asterisk in flavor text to fail.
- Added transformers set symbol.
- Creator tab bug fixes.